### PR TITLE
Better reader

### DIFF
--- a/src/prim_io.c
+++ b/src/prim_io.c
@@ -98,12 +98,6 @@ Expr* prim_scan_str(Env* env, Expr* e) {
             sl_safe_realloc(str, str_sz);
         }
 
-        /*
-         * FIXME: This ignores the `g_incoming' static variable from
-         * <read.c>. We could add some kind of interface for reading strings
-         * from there. Usually, this is only a problem when piping input, since
-         * an interactive user has to press <RET> after each input.
-         */
         const char c = getchar();
         if (c == EOF || c == '\0' || is_char_in_str(c, delimiters))
             break;

--- a/src/prim_io.c
+++ b/src/prim_io.c
@@ -98,6 +98,12 @@ Expr* prim_scan_str(Env* env, Expr* e) {
             sl_safe_realloc(str, str_sz);
         }
 
+        /*
+         * FIXME: This ignores the `g_incoming' static variable from
+         * <read.c>. We could add some kind of interface for reading strings
+         * from there. Usually, this is only a problem when piping input, since
+         * an interactive user has to press <RET> after each input.
+         */
         const char c = getchar();
         if (c == EOF || c == '\0' || is_char_in_str(c, delimiters))
             break;

--- a/src/read.c
+++ b/src/read.c
@@ -14,10 +14,16 @@
  *
  * You should have received a copy of the GNU General Public License along with
  * SL. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------------
+ *
+ * TODO: Rename these functions to "scanner", or something other than
+ * reader? Since Lisp's `read' also parses the input into an `Expr'.
  */
 
 #include <stdbool.h>
 #include <stdio.h>
+#include <ctype.h>
 
 #include "include/util.h"
 #include "include/read.h"
@@ -25,37 +31,18 @@
 
 #define READ_BUFSZ 100
 
+/*----------------------------------------------------------------------------*/
+
 /*
  * Is the specified character a comment start/end delimiter?
  */
 #define IS_COMMENT_START(C) ((c) == ';')
 #define IS_COMMENT_END(C)   ((c) == '\n')
 
-/*----------------------------------------------------------------------------*/
-
 /*
- * Did the character at `str[pos]' just open/close a string with a double-quote?
- * Checks if it was escaped:
- *
- *   (...")     -> true
- *   (...\\\")  -> false (odd '\')
- *   (...\\\\") -> true (even '\')
+ * Get the first non-comment character from `fp' using `fgetc'.  Doesn't
+ * check for EOF, it returns it literally.
  */
-static bool just_toggled_string_state(const char* str, int pos) {
-    if (str[pos] != '\"')
-        return false;
-    pos--;
-
-    /* Every consecutive backslash from the end, toggle the variable to store if
-     * the number is odd or even. */
-    bool odd_backslashes = true;
-    for (; pos >= 0 && str[pos] == '\\'; pos--)
-        odd_backslashes = !odd_backslashes;
-
-    return odd_backslashes;
-}
-
-/* Return the first non-comment character from `fp' */
 static int get_next_non_comment(FILE* fp) {
     int c = fgetc(fp);
 
@@ -77,22 +64,73 @@ static int get_next_non_comment(FILE* fp) {
 
 /*----------------------------------------------------------------------------*/
 
-char* read_expr(FILE* fp) {
+/*
+ * Read a double-quote-terminated string into the `dst' buffer, modifying its
+ * size and position. Assumes the opening double-quote has just been written to
+ * `dst'; reads up to the final non-escaped double-quote, included.
+ *
+ * The string will be reallocated if necessary, ensuring there is enough space
+ * for the null terminator after the closing double-quote, but without actually
+ * writing it.
+ *
+ * Returns true on success, or false if EOF was encountered (though note that
+ * nothing is freed from here).
+ */
+static bool read_user_string(FILE* fp, char** dst, size_t* dst_sz,
+                             size_t* dst_pos) {
+    /*
+     * Important notes:
+     *   - There are no comments (starting with ';') in strings.
+     *   - Null bytes are handled in the lexer, not here.
+     *   - A backslash is used to escape. In this "read" stage, we don't have to
+     *     check what is being escaped. Just store it literally.
+     *   - A string ends as long as a non-escaped double-quote is found.
+     *   - EOF might appear inside a string, in which case we should abort and
+     *     return false.
+     */
+    int c = 0;
+    while (c != '\"') {
+        if (*dst_pos + 2 >= *dst_sz) {
+            *dst_sz += READ_BUFSZ;
+            sl_safe_realloc(*dst, *dst_sz);
+        }
+
+        c = fgetc(fp);
+        if (c == EOF)
+            return false;
+
+        (*dst)[(*dst_pos)++] = c;
+
+        if (c == '\\') {
+            const int escaped = fgetc(fp);
+            if (escaped == EOF)
+                return false;
+
+            (*dst)[(*dst_pos)++] = escaped;
+        }
+    }
+
+    return true;
+}
+
+/*----------------------------------------------------------------------------*/
+
+/*
+ * Read a user list with the form "(...)". Assumes the caller just received an
+ * opening parentheses, but didn't write it anywhere.
+ */
+static char* read_user_list(FILE* fp) {
+    size_t result_pos = 0;
+    size_t result_sz  = READ_BUFSZ;
+    char* result      = sl_safe_malloc(result_sz);
+
     /* Will increase when encountering '(' and decrease with ')' */
-    int nesting_level = 0;
+    int nesting_level = 1;
 
-    /* If true, we found a symbol/constant with nesting_level at 0 */
-    bool isolated_symbol = false;
+    result[result_pos++] = '(';
 
-    /* If true, we are inside a user string in the form "..." */
-    bool inside_string = false;
-
-    size_t result_sz = READ_BUFSZ;
-    char* result     = sl_safe_malloc(result_sz);
-    size_t i         = 0;
-
-    for (;;) {
-        if (i >= result_sz - 1) {
+    while (nesting_level > 0) {
+        if (result_pos + 1 >= result_sz) {
             result_sz += READ_BUFSZ;
             sl_safe_realloc(result, result_sz);
         }
@@ -103,65 +141,144 @@ char* read_expr(FILE* fp) {
             return NULL;
         }
 
-        result[i++] = c;
+        result[result_pos++] = c;
 
         /*
-         * First, check if we are opening/closing a string. That static function
-         * will check for escaped double-quotes.
+         * If we encounter an opening or closing parentheses, simply increase or
+         * decrease the nesting level, respectively.
+         *
+         * If we encounter a double-quote, we should handle it similarly to
+         * `read_isolated_user_string', since parentheses should be ignored
+         * inside strings, escaped quotes should be handled, etc.
          */
-        if (just_toggled_string_state(result, i - 1))
-            inside_string = !inside_string;
+        switch (c) {
+            case '(': {
+                nesting_level++;
+            } break;
 
-        /*
-         * If we are inside a string, we don't want to check anything else until
-         * we close it.
-         */
-        if (inside_string)
-            continue;
-
-        if (c == '(') {
-            /*
-             * FIXME: On input "123(+ 1 2)", we should only read "123" on the
-             * first call, and "(+ 1 2)" on the second. Refactor this whole
-             * function.
-             */
-            nesting_level++;
-        } else if (c == ')') {
-            /*
-             * If we are still in level 0, we should have opened an
-             * expression. Just decrease `i' and ignore it.
-             *
-             * Otherwise, if we closed all the expressions that we opened, we
-             * are done.
-             */
-            if (nesting_level <= 0) {
-                SL_ERR("Encountered unmatched ')'.");
-                i--;
-            } else {
+            case ')': {
                 nesting_level--;
-                if (nesting_level <= 0)
-                    break;
-            }
-        } else if (nesting_level == 0) {
-            /*
-             * We are reading outside of an expression.
-             *
-             * If we weren't reading an isolated atom and this isn't a token
-             * separator, start reading the atom.
-             *
-             * Otherwise, if we were reading an isolated atom and we reached a
-             * token separator, we are done. Decrease `i' because the token
-             * separator we just read isn't part of the final string.
-             */
-            if (!isolated_symbol && !is_token_separator(c)) {
-                isolated_symbol = true;
-            } else if (isolated_symbol && is_token_separator(c)) {
-                i--;
+            } break;
+
+            case '\"': {
+                if (!read_user_string(fp, &result, &result_sz, &result_pos)) {
+                    free(result);
+                    return NULL;
+                }
+            } break;
+
+            default:
                 break;
-            }
         }
     }
 
-    result[i] = '\0';
+    result[result_pos] = '\0';
     return result;
+}
+
+/*
+ * Read an isolated user string.  Assumes the caller just received a
+ * double-quote, but didn't write it anywhere. Writes the opening double-quote,
+ * reads a string using the `read_user_string' function (used in other places),
+ * checks if it contained EOF, and writes the final null terminator.
+ */
+static char* read_isolated_user_string(FILE* fp) {
+    size_t result_pos = 0;
+    size_t result_sz  = READ_BUFSZ;
+    char* result      = sl_safe_malloc(result_sz);
+
+    result[result_pos++] = '\"';
+
+    if (!read_user_string(fp, &result, &result_sz, &result_pos)) {
+        free(result);
+        return NULL;
+    }
+
+    result[result_pos] = '\0';
+    return result;
+}
+
+/*
+ * Reads characters until a token separator is found.
+ *
+ * FIXME: On input "123(+ 1 2)", we should only read "123" on the first call,
+ * and "(+ 1 2)" on the second. How do we store that token separator for next
+ * calls. `g_incoming'?
+ *
+ * TODO: If using `g_incoming', remove `first_char' parameter.
+ */
+static char* read_isolated_atom(FILE* fp, char first_char) {
+    size_t result_pos = 0;
+    size_t result_sz  = READ_BUFSZ;
+    char* result      = sl_safe_malloc(result_sz);
+
+    result[result_pos++] = first_char;
+
+    /*
+     * Read until any token separator. This includes spaces, but also
+     * parentheses, for example. The `is_token_separator' function is declared
+     * in <lexer.h>.
+     */
+    for (;;) {
+        if (result_pos + 1 >= result_sz) {
+            result_sz += READ_BUFSZ;
+            sl_safe_realloc(result, result_sz);
+        }
+
+        const int c = get_next_non_comment(fp);
+        if (c == EOF) {
+            free(result);
+            return NULL;
+        }
+
+        if (is_token_separator(c))
+            break;
+
+        result[result_pos++] = c;
+    }
+
+    result[result_pos] = '\0';
+    return result;
+}
+
+/*----------------------------------------------------------------------------*/
+
+char* read_expr(FILE* fp) {
+    /* Skip preceding spaces or comments, if any */
+    int c;
+    do {
+        c = get_next_non_comment(fp);
+    } while (isspace(c));
+
+    if (c == EOF)
+        return NULL;
+
+    /*
+     * The first character (which is guaranteed to not be EOF) will indicate
+     * where we should stop parsing the current expression:
+     *
+     * - If we are opening a parentheses, we stop at the closing parentheses at
+     *   that same level (that is not inside a string).
+     * - If we are opening a double-quoted string, we stop at the first
+     *   non-escaped double-quote.
+     * - Otherwise, we are reading an isolated atom.
+     *
+     * We also check for some invalid characters:
+     *
+     * - If we encountered a closing parentheses in level 0, it is unmatched.
+     */
+    switch (c) {
+        case '(':
+            return read_user_list(fp);
+
+        case ')':
+            SL_ERR("Encountered unmatched ')'.");
+            return sl_safe_strdup("");
+
+        case '\"':
+            return read_isolated_user_string(fp);
+
+        default:
+            return read_isolated_atom(fp, c);
+    }
 }

--- a/src/read.c
+++ b/src/read.c
@@ -36,8 +36,8 @@
 /*
  * Is the specified character a comment start/end delimiter?
  */
-#define IS_COMMENT_START(C) ((c) == ';')
-#define IS_COMMENT_END(C)   ((c) == '\n')
+#define IS_COMMENT_START(C) ((C) == ';')
+#define IS_COMMENT_END(C)   ((C) == '\n')
 
 /*
  * Get the first non-comment character from `fp' using `fgetc'.  Doesn't

--- a/src/read.c
+++ b/src/read.c
@@ -273,7 +273,7 @@ char* read_expr(FILE* fp) {
 
         case ')':
             SL_ERR("Encountered unmatched ')'.");
-            return sl_safe_strdup("");
+            return read_expr(fp);
 
         case '\"':
             return read_isolated_user_string(fp);

--- a/src/read.c
+++ b/src/read.c
@@ -164,17 +164,17 @@ static char* read_user_list(FILE* fp) {
          * inside strings, escaped quotes should be handled, etc.
          */
         switch (c) {
-            case '(': {
+            case '(':
                 nesting_level++;
-            } break;
+                break;
 
-            case ')': {
+            case ')':
                 nesting_level--;
-            } break;
+                break;
 
-            case '\"': {
+            case '\"':
                 read_user_string(fp, &result, &result_sz, &result_pos);
-            } break;
+                break;
 
             default:
                 break;
@@ -239,7 +239,7 @@ static char* read_isolated_atom(FILE* fp) {
 char* read_expr(FILE* fp) {
     int incoming = get_incoming(fp);
 
-    /* Skip preceding spaces or comments, if any */
+    /* Skip leading spaces or comments, if any */
     while (isspace(incoming) || IS_COMMENT_START(incoming)) {
         fgetc(fp);
         read_until_incoming_non_comment(fp);

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -31,8 +31,8 @@ for file in $(ls "$SCRIPT_DIR"/*.lisp); do
 
     input_str=""
     if [ "$(basename "$file")" == "io.lisp" ]; then
-        input_str+="123\n"
-        input_str+="(+ 1 2 3 (- 5 4))\n"
+        input_str+="123"
+        input_str+="(+ 1 2 3 (- 5 4))"
         input_str+="User string...\n"
         input_str+="Another delimited line. EXTRA"
     fi

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -31,8 +31,8 @@ for file in $(ls "$SCRIPT_DIR"/*.lisp); do
 
     input_str=""
     if [ "$(basename "$file")" == "io.lisp" ]; then
-        input_str+="123 "
-        input_str+="(+ 1 2 3 (- 5 4))"
+        input_str+="123\n"
+        input_str+="(+ 1 2 3 (- 5 4))\n"
         input_str+="User string...\n"
         input_str+="Another delimited line. EXTRA"
     fi


### PR DESCRIPTION
Split `read_expr` into different functions. Way clearer and more maintainable.

Fixes the comment from that same function, which isn't directly related to the
refactoring.

Changes:
- Add `get_incoming`
- Add `read_until_incoming_non_comment`, simplify `get_next_non_comment`.
- Remove `just_toggled_string_state` function, replace with `read_user_string`.
- Add `read_user_list`, `read_isolated_user_string` and `read_isolated_atom`
  functions. One of these will be dispatched from `read_expr`.
- Skip leading spaces/comments from `read_expr`.

Some commits added a comment to `prim_io.c`, but it has been fixed in this same PR.