### PR TITLE
Better error handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ CC=gcc
 CFLAGS=-std=gnu99 -Wall -Wextra -ggdb3
 LDLIBS=-lm
 
-SRCS=main.c expr.c env.c lambda.c util.c debug.c read.c lexer.c parser.c eval.c prim_special.c prim_general.c prim_logic.c prim_type.c prim_list.c prim_string.c prim_arith.c prim_bitwise.c prim_io.c
+SRCS=main.c expr.c env.c lambda.c util.c error.c debug.c read.c lexer.c parser.c eval.c prim_special.c prim_general.c prim_logic.c prim_type.c prim_list.c prim_string.c prim_arith.c prim_bitwise.c prim_io.c
 OBJS=$(addprefix obj/, $(addsuffix .o, $(SRCS)))
 
 BIN=sl

--- a/src/env.c
+++ b/src/env.c
@@ -198,6 +198,9 @@ Env* env_clone(Env* env) {
 }
 
 void env_free(Env* env) {
+    if (env == NULL)
+        return;
+
     for (size_t i = 0; i < env->size; i++) {
         free(env->bindings[i].sym);
         expr_free(env->bindings[i].val);

--- a/src/env.c
+++ b/src/env.c
@@ -213,7 +213,6 @@ bool env_bind(Env* env, const char* sym, const Expr* val,
               enum EEnvBindingFlags flags) {
     SL_ASSERT(env != NULL);
     SL_ASSERT(sym != NULL);
-    SL_ON_ERR(return false);
 
     /*
      * Before creating a new item in the environment, traverse the existing
@@ -230,8 +229,8 @@ bool env_bind(Env* env, const char* sym, const Expr* val,
      */
     for (size_t i = 0; i < env->size; i++) {
         if (strcmp(env->bindings[i].sym, sym) == 0) {
-            SL_EXPECT((env->bindings[i].flags & ENV_FLAG_CONST) == 0,
-                      "Trying to set constant symbol `%s'.", sym);
+            if ((env->bindings[i].flags & ENV_FLAG_CONST) != 0)
+                return false;
 
             expr_free(env->bindings[i].val);
             env->bindings[i].val   = expr_clone_recur(val);

--- a/src/env.c
+++ b/src/env.c
@@ -27,14 +27,14 @@
 #include "include/primitives.h"
 
 /* Used in `env_init_defaults' */
-#define BIND_PRIM_FLAGS(ENV, SYM, FUNC, FLAGS)   \
-    do {                                         \
-        Expr FUNC##_expr = {                     \
-            .type     = EXPR_PRIM,               \
-            .val.prim = prim_##FUNC,             \
-            .next     = NULL,                    \
-        };                                       \
-        env_bind(ENV, SYM, &FUNC##_expr, FLAGS); \
+#define BIND_PRIM_FLAGS(ENV, SYM, FUNC, FLAGS)              \
+    do {                                                    \
+        Expr FUNC##_expr = {                                \
+            .type     = EXPR_PRIM,                          \
+            .val.prim = prim_##FUNC,                        \
+            .next     = NULL,                               \
+        };                                                  \
+        SL_ASSERT(env_bind(ENV, SYM, &FUNC##_expr, FLAGS)); \
     } while (0)
 
 #define BIND_PRIM(ENV, SYM, FUNC) BIND_PRIM_FLAGS(ENV, SYM, FUNC, ENV_FLAG_NONE)
@@ -84,15 +84,15 @@ void env_init_defaults(Env* env) {
      * Since the expressions will be cloned, it's safe to pass the stack address
      * to `env_bind'.
      */
-    env_bind(env, "nil", nil, ENV_FLAG_CONST);
-    env_bind(env, "tru", tru, ENV_FLAG_CONST);
+    SL_ASSERT(env_bind(env, "nil", nil, ENV_FLAG_CONST));
+    SL_ASSERT(env_bind(env, "tru", tru, ENV_FLAG_CONST));
 
     Expr debug_trace_list = {
         .type         = EXPR_PARENT,
         .val.children = NULL,
         .next         = NULL,
     };
-    env_bind(env, "*debug-trace*", &debug_trace_list, ENV_FLAG_NONE);
+    SL_ASSERT(env_bind(env, "*debug-trace*", &debug_trace_list, ENV_FLAG_NONE));
 
     /* Special forms */
     BIND_SPECIAL(env, "quote", quote);

--- a/src/error.c
+++ b/src/error.c
@@ -23,6 +23,12 @@
 #include "include/error.h"
 #include "include/expr.h"
 
+#define COL_RESET       "\e[0m"
+#define COL_NORM_YELLOW "\e[0;33m"
+#define COL_NORM_RED    "\e[0;31m"
+#define COL_BOLD_CYAN   "\e[1;36m"
+#define COL_BOLD_RED    "\e[1;31m"
+
 Expr* err(const char* fmt, ...) {
     /*
      * TODO: If compiled with SL_TRACE_ON_ERR, somehow print call stack as soon
@@ -46,13 +52,20 @@ Expr* err(const char* fmt, ...) {
     return ret;
 }
 
-/*----------------------------------------------------------------------------*/
+void err_print(FILE* fp, const Expr* e) {
+    SL_ASSERT(e != NULL);
+    SL_ASSERT(e->type == EXPR_ERR);
+    SL_ASSERT(e->val.s != NULL);
 
-#define COL_RESET       "\e[0m"
-#define COL_NORM_YELLOW "\e[0;33m"
-#define COL_NORM_RED    "\e[0;31m"
-#define COL_BOLD_CYAN   "\e[1;36m"
-#define COL_BOLD_RED    "\e[1;31m"
+#ifdef SL_NO_COLOR
+    fprintf(fp, "Error: %s", e->val.s);
+#else
+    fprintf(fp, "%sError%s: %s%s%s", COL_BOLD_RED, COL_RESET, COL_NORM_YELLOW,
+            e->val.s, COL_RESET);
+#endif
+}
+
+/*----------------------------------------------------------------------------*/
 
 void sl_print_err(const char* func, const char* fmt, ...) {
     va_list va;

--- a/src/error.c
+++ b/src/error.c
@@ -19,7 +19,34 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#include "include/util.h"
 #include "include/error.h"
+#include "include/expr.h"
+
+Expr* err(const char* fmt, ...) {
+    /*
+     * TODO: If compiled with SL_TRACE_ON_ERR, somehow print call stack as soon
+     * as this function is entered (for debugging, no need to integrate it into
+     * EXPR_ERR).
+     */
+    va_list va;
+
+    va_start(va, fmt);
+    const int data_size = vsnprintf(NULL, 0, fmt, va);
+    va_end(va);
+
+    char* result = sl_safe_malloc(data_size + 1);
+
+    va_start(va, fmt);
+    vsnprintf(result, data_size + 1, fmt, va);
+    va_end(va);
+
+    Expr* ret  = expr_new(EXPR_ERR);
+    ret->val.s = result;
+    return ret;
+}
+
+/*----------------------------------------------------------------------------*/
 
 #define COL_RESET       "\e[0m"
 #define COL_NORM_YELLOW "\e[0;33m"

--- a/src/error.c
+++ b/src/error.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2024 8dcc
+ *
+ * This file is part of SL.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <stdarg.h>
+#include <stdio.h>
+
+#include "include/error.h"
+
+#define COL_RESET       "\e[0m"
+#define COL_NORM_YELLOW "\e[0;33m"
+#define COL_NORM_RED    "\e[0;31m"
+#define COL_BOLD_CYAN   "\e[1;36m"
+#define COL_BOLD_RED    "\e[1;31m"
+
+void sl_print_err(const char* func, const char* fmt, ...) {
+    va_list va;
+    va_start(va, fmt);
+
+#ifdef SL_NO_COLOR
+    fprintf(stderr, "%s: ", func);
+    vfprintf(stderr, fmt, va);
+#else
+    fprintf(stderr, "%s%s%s: %s", COL_BOLD_CYAN, func, COL_RESET,
+            COL_NORM_YELLOW);
+    vfprintf(stderr, fmt, va);
+    fprintf(stderr, "%s", COL_RESET);
+#endif
+
+    fputc('\n', stderr);
+
+    va_end(va);
+}
+
+void sl_print_ftl(const char* file, int line, const char* func, const char* fmt,
+                  ...) {
+    va_list va;
+    va_start(va, fmt);
+
+#ifdef SL_NO_COLOR
+    fprintf(stderr, "%s:%d: %s: ", file, line, func);
+    vfprintf(stderr, fmt, va);
+#else
+    fprintf(stderr, "%s:%d: %s%s%s: %s", file, line, COL_BOLD_CYAN, func,
+            COL_RESET, COL_NORM_RED);
+    vfprintf(stderr, fmt, va);
+    fprintf(stderr, "%s", COL_RESET);
+#endif
+
+    fputc('\n', stderr);
+
+    va_end(va);
+}

--- a/src/eval.c
+++ b/src/eval.c
@@ -184,10 +184,12 @@ Expr* eval(Env* env, Expr* e) {
         case EXPR_STRING:
         case EXPR_PRIM:
         case EXPR_LAMBDA:
-        case EXPR_MACRO: {
+        case EXPR_MACRO:
             /* Not a parent nor a symbol, evaluates to itself */
             return expr_clone(e);
-        }
+
+        case EXPR_UNKNOWN:
+            SL_FATAL("Tried to evaluate an expression of type 'Unknown'.");
     }
 
     SL_FATAL("Reached unexpected point, didn't return from switch.");

--- a/src/eval.c
+++ b/src/eval.c
@@ -54,17 +54,21 @@ static Expr* eval_list(Env* env, Expr* list) {
     Expr* cur_copy  = &dummy_copy;
 
     for (Expr* cur = list; cur != NULL; cur = cur->next) {
-        /* Evaluate original argument, save it in our copy */
-        cur_copy->next = eval(env, cur);
-
-        /* Move to the next argument in our copy list */
-        cur_copy = cur_copy->next;
-
-        /* Failed to evaluate an item. Free what we had evaluated and stop. */
-        if (cur_copy == NULL) {
+        /*
+         * Evaluate each argument. If one of them returns an error, free what we
+         * had evaluated and propagate it upwards.
+         *
+         * Otherwise, save the evaluation in our copy, and move to the next
+         * argument in our linked list.
+         */
+        Expr* evaluated = eval(env, cur);
+        if (EXPRP_ERR(evaluated)) {
             expr_list_free(dummy_copy.next);
-            return NULL;
+            return evaluated;
         }
+
+        cur_copy->next = evaluated;
+        cur_copy       = cur_copy->next;
     }
 
     return dummy_copy.next;
@@ -76,8 +80,6 @@ static Expr* eval_list(Env* env, Expr* list) {
  * (using `eval_list') before applying the function, if necessary.
  */
 static Expr* eval_function_call(Env* env, Expr* e) {
-    SL_ON_ERR(return NULL);
-
     /* Caller should have checked if `e' is `nil' */
     SL_ASSERT(e->val.children != NULL);
 
@@ -95,8 +97,8 @@ static Expr* eval_function_call(Env* env, Expr* e) {
      * we are done.
      */
     Expr* func = eval(env, car);
-    if (func == NULL)
-        return NULL;
+    if (EXPRP_ERR(func))
+        return func;
     SL_EXPECT(EXPRP_APPLICABLE(func), "Expected function or macro, got '%s'.",
               exprtype2str(func->type));
 
@@ -124,9 +126,9 @@ static Expr* eval_function_call(Env* env, Expr* e) {
     Expr* args;
     if (should_eval_args) {
         args = eval_list(env, cdr);
-        if (args == NULL) {
+        if (EXPRP_ERR(args)) {
             expr_free(func);
-            return NULL;
+            return args;
         }
     } else {
         args = cdr;
@@ -137,6 +139,8 @@ static Expr* eval_function_call(Env* env, Expr* e) {
 
     /* Apply the evaluated function to the evaluated argument list */
     Expr* applied = apply(env, func, args);
+    if (applied == NULL)
+        applied = err("Unknown error (?)");
 
     /* The evaluations of `func' and `args' returned clones */
     expr_free(func);
@@ -150,8 +154,6 @@ static Expr* eval_function_call(Env* env, Expr* e) {
 }
 
 Expr* eval(Env* env, Expr* e) {
-    SL_ON_ERR(return NULL);
-
     if (e == NULL)
         return NULL;
 
@@ -246,9 +248,8 @@ Expr* apply(Env* env, Expr* func, Expr* args) {
         } break;
 
         default: {
-            err("Expected 'Primitive' or 'Lambda', got '%s'.",
-                exprtype2str(func->type));
-            result = NULL;
+            result = err("Expected 'Primitive' or 'Lambda', got '%s'.",
+                         exprtype2str(func->type));
         } break;
     }
 

--- a/src/expr.c
+++ b/src/expr.c
@@ -494,7 +494,6 @@ bool expr_write(FILE* fp, const Expr* e) {
         case EXPR_ERR:
         case EXPR_PRIM:
         case EXPR_UNKNOWN:
-            err("Can't write expressions of type '%s'.", exprtype2str(e->type));
             return false;
     }
 

--- a/src/expr.c
+++ b/src/expr.c
@@ -410,7 +410,11 @@ void expr_print(FILE* fp, const Expr* e) {
             break;
 
         case EXPR_ERR:
-            fprintf(fp, "Error: %s\n", e->val.s);
+            /*
+             * TODO: Print with color if SL_NO_COLOR is not defined, similar to
+             * `sl_print_err'.
+             */
+            fprintf(fp, "Error: %s", e->val.s);
             break;
 
         case EXPR_PARENT:

--- a/src/expr.c
+++ b/src/expr.c
@@ -512,7 +512,6 @@ void expr_print_debug(FILE* fp, const Expr* e) {
         fputc(' ', fp);
 
     if (e == NULL) {
-        fprintf(fp, "[ERR] ");
         SL_ERR("Unexpected NULL expression. Returning...");
         return;
     }

--- a/src/expr.c
+++ b/src/expr.c
@@ -59,6 +59,7 @@ void expr_free(Expr* e) {
             break;
 
         case EXPR_ERR:
+        case EXPR_UNKNOWN:
         case EXPR_NUM_INT:
         case EXPR_NUM_FLT:
         case EXPR_PRIM:
@@ -119,6 +120,7 @@ Expr* expr_clone(const Expr* e) {
             break;
 
         case EXPR_ERR:
+        case EXPR_UNKNOWN:
             SL_ERR("Trying to clone <error>");
             break;
     }
@@ -243,6 +245,7 @@ bool expr_equal(const Expr* a, const Expr* b) {
             return lambda_ctx_equal(a->val.lambda, b->val.lambda);
 
         case EXPR_ERR:
+        case EXPR_UNKNOWN:
             return false;
     }
 
@@ -278,6 +281,7 @@ bool expr_lt(const Expr* a, const Expr* b) {
         case EXPR_LAMBDA:
         case EXPR_MACRO:
         case EXPR_ERR:
+        case EXPR_UNKNOWN:
             return false;
     }
 
@@ -309,6 +313,7 @@ bool expr_gt(const Expr* a, const Expr* b) {
         case EXPR_LAMBDA:
         case EXPR_MACRO:
         case EXPR_ERR:
+        case EXPR_UNKNOWN:
             return false;
     }
 
@@ -426,6 +431,10 @@ void expr_print(FILE* fp, const Expr* e) {
         case EXPR_ERR:
             fprintf(fp, "<error>");
             break;
+
+        case EXPR_UNKNOWN:
+            fprintf(fp, "<unknown>");
+            break;
     }
 }
 
@@ -482,8 +491,9 @@ bool expr_write(FILE* fp, const Expr* e) {
             fputc(')', fp);
             break;
 
-        case EXPR_PRIM:
         case EXPR_ERR:
+        case EXPR_PRIM:
+        case EXPR_UNKNOWN:
             err("Expressions of type '%s' can't be converted to a string.",
                 exprtype2str(e->type));
             return false;
@@ -568,6 +578,11 @@ void expr_print_debug(FILE* fp, const Expr* e) {
 
         case EXPR_ERR: {
             fprintf(fp, "[ERR] (Stopping)");
+            return;
+        }
+
+        case EXPR_UNKNOWN: {
+            fprintf(fp, "[UNK] (Stopping)");
             return;
         }
     }

--- a/src/expr.c
+++ b/src/expr.c
@@ -414,7 +414,7 @@ void expr_print(FILE* fp, const Expr* e) {
              * TODO: Print with color if SL_NO_COLOR is not defined, similar to
              * `sl_print_err'.
              */
-            fprintf(fp, "Error: %s", e->val.s);
+            err_print(stderr, e);
             break;
 
         case EXPR_PARENT:

--- a/src/include/env.h
+++ b/src/include/env.h
@@ -91,6 +91,11 @@ void env_free(Env* env);
  *
  * Returns true on success, or false on failure. The caller is responsible for
  * checking the returned value and handling errors.
+ *
+ * TODO: In the future, if this function fails with multiple conditions
+ * (e.g. after adding more `EEnvBindingFlags'), we should create a new enum and
+ * return an error code. The caller should check if the function succeeded, and
+ * if not, print the returned value of some `env_strerror' function.
  */
 bool env_bind(Env* env, const char* sym, const struct Expr* val,
               enum EEnvBindingFlags flags);

--- a/src/include/env.h
+++ b/src/include/env.h
@@ -88,6 +88,9 @@ void env_free(Env* env);
 /*
  * Bind the symbol `sym' to the expression `val' in environment `env', with the
  * specified `flags'.
+ *
+ * Returns true on success, or false on failure. The caller is responsible for
+ * checking the returned value and handling errors.
  */
 bool env_bind(Env* env, const char* sym, const struct Expr* val,
               enum EEnvBindingFlags flags);

--- a/src/include/error.h
+++ b/src/include/error.h
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2024 8dcc
+ *
+ * This file is part of SL.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef ERROR_H_
+#define ERROR_H_ 1
+
+#include <stdlib.h> /* exit() */
+
+/*
+ * Wrapper for `sl_print_err'. Should only be used for errors about the
+ * interpreter itself; for Lisp errors, use the `err' function.
+ */
+#define SL_ERR(...) sl_print_err(__func__, __VA_ARGS__)
+
+/*
+ * Handle Lisp errors.
+ *
+ * TODO: This should be a function that doesn't print anything, but instead
+ * returns an EXPR_ERR that gets propagated upwards.
+ */
+#define err SL_ERR
+
+/*
+ * Show error message with `sl_print_ftl' and exit.
+ */
+#define SL_FATAL(...)                                            \
+    do {                                                         \
+        sl_print_ftl(__FILE__, __LINE__, __func__, __VA_ARGS__); \
+        exit(1);                                                 \
+    } while (0)
+
+/*
+ * If COND is zero, show error message and exit.
+ */
+#define SL_ASSERT(COND)                                  \
+    do {                                                 \
+        if ((COND) == 0) {                               \
+            SL_FATAL("Assertion `%s' failed.\n", #COND); \
+        }                                                \
+    } while (0)
+
+/*
+ * Set the instruction(s) to be executed when SL_EXPECT() fails.
+ */
+#define SL_ON_ERR(INSTRUCTIONS) \
+    if (0) {                    \
+sl_lbl_on_err:                  \
+        INSTRUCTIONS;           \
+    }
+
+/*
+ * If COND is not true, show warning and jump to instruction declared by
+ * SL_ON_ERR().
+ *
+ * TODO: Instea of using SL_ON_ERR, return the EXPR_ERR returned by `err'.
+ */
+#define SL_EXPECT(COND, ...)                                         \
+    do {                                                             \
+        if ((COND) == 0) {                                           \
+            err(__VA_ARGS__);                                        \
+            goto sl_lbl_on_err; /* Make sure you call SL_ON_ERR() */ \
+        }                                                            \
+    } while (0)
+
+/*
+ * Check if the specified linked list of `Expr' structures has a specific
+ * length using `SL_EXPECT'.
+ */
+#define SL_EXPECT_ARG_NUM(EXPR_LIST, NUM)                    \
+    SL_EXPECT(expr_list_len(EXPR_LIST) == (NUM),             \
+              "Expected exactly %d arguments, got %d.", NUM, \
+              expr_list_len(EXPR_LIST))
+
+/*
+ * Check if the specified expression matches the expected type using
+ * `SL_EXPECT'.
+ */
+#define SL_EXPECT_TYPE(EXPR, TYPE)                           \
+    SL_EXPECT((EXPR)->type == (TYPE),                        \
+              "Expected expression of type '%s', got '%s'.", \
+              exprtype2str(TYPE), exprtype2str((EXPR)->type))
+
+/*----------------------------------------------------------------------------*/
+
+/*
+ * Print different error messages to stderr, along with some context
+ * information.
+ */
+void sl_print_err(const char* func, const char* fmt, ...);
+void sl_print_ftl(const char* file, int line, const char* func, const char* fmt,
+                  ...);
+
+#endif /* ERROR_H_ */

--- a/src/include/error.h
+++ b/src/include/error.h
@@ -21,19 +21,15 @@
 
 #include <stdlib.h> /* exit() */
 
+struct Expr;
+
+/*----------------------------------------------------------------------------*/
+
 /*
  * Wrapper for `sl_print_err'. Should only be used for errors about the
  * interpreter itself; for Lisp errors, use the `err' function.
  */
 #define SL_ERR(...) sl_print_err(__func__, __VA_ARGS__)
-
-/*
- * Handle Lisp errors.
- *
- * TODO: This should be a function that doesn't print anything, but instead
- * returns an EXPR_ERR that gets propagated upwards.
- */
-#define err SL_ERR
 
 /*
  * Show error message with `sl_print_ftl' and exit.
@@ -55,26 +51,14 @@
     } while (0)
 
 /*
- * Set the instruction(s) to be executed when SL_EXPECT() fails.
+ * If COND is not true, return expression of type EXPR_ERR with the specified
+ * message.
  */
-#define SL_ON_ERR(INSTRUCTIONS) \
-    if (0) {                    \
-sl_lbl_on_err:                  \
-        INSTRUCTIONS;           \
-    }
-
-/*
- * If COND is not true, show warning and jump to instruction declared by
- * SL_ON_ERR().
- *
- * TODO: Instea of using SL_ON_ERR, return the EXPR_ERR returned by `err'.
- */
-#define SL_EXPECT(COND, ...)                                         \
-    do {                                                             \
-        if ((COND) == 0) {                                           \
-            err(__VA_ARGS__);                                        \
-            goto sl_lbl_on_err; /* Make sure you call SL_ON_ERR() */ \
-        }                                                            \
+#define SL_EXPECT(COND, ...)         \
+    do {                             \
+        if ((COND) == 0) {           \
+            return err(__VA_ARGS__); \
+        }                            \
     } while (0)
 
 /*
@@ -96,6 +80,13 @@ sl_lbl_on_err:                  \
               exprtype2str(TYPE), exprtype2str((EXPR)->type))
 
 /*----------------------------------------------------------------------------*/
+
+/*
+ * Create a new error expression with the specified message. This function
+ * doesn't directly print anything; the error is supposed to get propagated
+ * upwards.
+ */
+struct Expr* err(const char* fmt, ...);
 
 /*
  * Print different error messages to stderr, along with some context

--- a/src/include/error.h
+++ b/src/include/error.h
@@ -43,11 +43,11 @@ struct Expr;
 /*
  * If COND is zero, show error message and exit.
  */
-#define SL_ASSERT(COND)                                  \
-    do {                                                 \
-        if ((COND) == 0) {                               \
-            SL_FATAL("Assertion `%s' failed.\n", #COND); \
-        }                                                \
+#define SL_ASSERT(COND)                                \
+    do {                                               \
+        if ((COND) == 0) {                             \
+            SL_FATAL("Assertion `%s' failed.", #COND); \
+        }                                              \
     } while (0)
 
 /*
@@ -89,8 +89,18 @@ struct Expr;
 struct Expr* err(const char* fmt, ...);
 
 /*
- * Print different error messages to stderr, along with some context
- * information.
+ * Print an expression of type `EXPR_ERR' into the specified file. Doesn't print
+ * a final newline.
+ *
+ * Will use colors unless `SL_NO_COLOR' is defined.
+ */
+void err_print(FILE* fp, const struct Expr* e);
+
+/*
+ * Print different error messages to `stderr', along with some context
+ * information. Prints a final newline.
+ *
+ * Will use colors unless `SL_NO_COLOR' is defined.
  */
 void sl_print_err(const char* func, const char* fmt, ...);
 void sl_print_ftl(const char* file, int line, const char* func, const char* fmt,

--- a/src/include/expr.h
+++ b/src/include/expr.h
@@ -34,15 +34,15 @@ struct LambdaCtx; /* lambda.h */
 typedef struct Expr* (*PrimitiveFuncPtr)(struct Env*, struct Expr*);
 
 enum EExprType {
-    EXPR_ERR     = 0x0,
-    EXPR_NUM_INT = 0x1,
-    EXPR_NUM_FLT = 0x2,
-    EXPR_SYMBOL  = 0x4,
-    EXPR_STRING  = 0x8,
-    EXPR_PARENT  = 0x10,
-    EXPR_PRIM    = 0x20,
-    EXPR_LAMBDA  = 0x40,
-    EXPR_MACRO   = 0x80,
+    EXPR_ERR     = (1 << 0),
+    EXPR_NUM_INT = (1 << 1),
+    EXPR_NUM_FLT = (1 << 2),
+    EXPR_SYMBOL  = (1 << 3),
+    EXPR_STRING  = (1 << 4),
+    EXPR_PARENT  = (1 << 5),
+    EXPR_PRIM    = (1 << 6),
+    EXPR_LAMBDA  = (1 << 7),
+    EXPR_MACRO   = (1 << 8),
 };
 
 typedef struct Expr Expr;

--- a/src/include/expr.h
+++ b/src/include/expr.h
@@ -21,9 +21,9 @@
 
 #include <stddef.h>
 #include <stdbool.h>
-#include <stdio.h> /* FILE, putchar() */
+#include <stdio.h> /* FILE, fputc() */
 
-#include "util.h" /* SL_FATAL() */
+#include "error.h" /* SL_FATAL() */
 
 struct Env;       /* env.h */
 struct LambdaCtx; /* lambda.h */

--- a/src/include/expr.h
+++ b/src/include/expr.h
@@ -34,9 +34,10 @@ struct LambdaCtx; /* lambda.h */
 typedef struct Expr* (*PrimitiveFuncPtr)(struct Env*, struct Expr*);
 
 enum EExprType {
-    EXPR_ERR     = (1 << 0),
-    EXPR_NUM_INT = (1 << 1),
-    EXPR_NUM_FLT = (1 << 2),
+    EXPR_UNKNOWN = 0,
+    EXPR_NUM_INT = (1 << 0),
+    EXPR_NUM_FLT = (1 << 1),
+    EXPR_ERR     = (1 << 2),
     EXPR_SYMBOL  = (1 << 3),
     EXPR_STRING  = (1 << 4),
     EXPR_PARENT  = (1 << 5),
@@ -235,9 +236,10 @@ static inline void expr_println(FILE* fp, const Expr* e) {
 static inline const char* exprtype2str(enum EExprType type) {
     /* clang-format off */
     switch (type) {
-        case EXPR_ERR:     return "Error";
+        case EXPR_UNKNOWN: return "Unknown";
         case EXPR_NUM_INT: return "Integer";
         case EXPR_NUM_FLT: return "Float";
+        case EXPR_ERR:     return "Error";
         case EXPR_SYMBOL:  return "Symbol";
         case EXPR_STRING:  return "String";
         case EXPR_PARENT:  return "List";

--- a/src/include/lambda.h
+++ b/src/include/lambda.h
@@ -25,8 +25,13 @@
 struct Expr; /* expr.h */
 struct Env;  /* env.h */
 
-typedef struct LambdaCtx LambdaCtx;
+enum ELambdaCtxErr {
+    LAMBDACTX_ERR_NONE = 0,
+    LAMBDACTX_ERR_FORMALTYPE,
+    LAMBDACTX_ERR_NOREST,
+};
 
+typedef struct LambdaCtx LambdaCtx;
 struct LambdaCtx {
     /* Environment for binding the formal arguments to the actual values when
      * calling the lambda. */
@@ -41,14 +46,35 @@ struct LambdaCtx {
     char* formal_rest;
 
     /* List of expressions to be evaluated in order when calling the lambda */
-    Expr* body;
+    struct Expr* body;
 };
 
+/*----------------------------------------------------------------------------*/
+
 /*
- * Allocate and initialize a new `LambdaCtx' structure using the specified
- * formal arguments and the specified list of body expressions.
+ * Return an immutable string that describes the specified error.
  */
-LambdaCtx* lambda_ctx_new(const struct Expr* formals, const struct Expr* body);
+const char* lambda_ctx_strerror(enum ELambdaCtxErr code);
+
+/*----------------------------------------------------------------------------*/
+/* TODO: Rename `lambda_ctx*' to `lambdactx_*' */
+
+/*
+ * Allocate an empty `LambdaCtx' structure. Should be freed by the caller with
+ * `lambda_ctx_free'. See also `lambda_ctx_init'.
+ */
+LambdaCtx* lambda_ctx_new(void);
+
+/*
+ * Initialize a new `LambdaCtx' structure using the specified formal arguments
+ * and the specified body. Note that the `body' argument is a linked list of
+ * expressions.
+ *
+ * The function returns an error code, which the caller should check, and
+ * optionally print with `lambda_ctx_strerror'.
+ */
+enum ELambdaCtxErr lambda_ctx_init(LambdaCtx* ctx, const struct Expr* formals,
+                                   const struct Expr* body);
 
 /*
  * Copy the specified `LambdaCtx' structure into an allocated copy, and return

--- a/src/include/util.h
+++ b/src/include/util.h
@@ -20,98 +20,23 @@
 #define UTIL_H_ 1
 
 #include <stdbool.h>
-#include <stdio.h>  /* FILE, fprintf() */
-#include <stdlib.h> /* exit() */
+#include <stddef.h>
+#include <stdio.h>  /* FILE */
+#include <stdlib.h> /* realloc() */
 #include <regex.h>  /* regmatch_t */
+
+#include "error.h" /* SL_FATAL() */
 
 /*----------------------------------------------------------------------------*/
 
 /* See strtoll(3) */
 #define STRTOLL_ANY_BASE 0
 
-/*----------------------------------------------------------------------------*/
-
 #define LENGTH(ARR) ((int)(sizeof(ARR) / sizeof((ARR)[0])))
 
 #define MIN(A, B)        ((A) < (B) ? (A) : (B))
 #define MAX(A, B)        ((A) > (B) ? (A) : (B))
 #define CLAMP(N, LO, HI) (MIN(MAX((LO), (N)), (HI)))
-
-/*
- * Wrapper for `sl_print_err'. Should only be used for errors about the
- * interpreter itself; for Lisp errors, use the `err' function.
- */
-#define SL_ERR(...) sl_print_err(__func__, __VA_ARGS__)
-
-/*
- * Handle Lisp errors.
- *
- * TODO: This should be a function that doesn't print anything, but instead
- * returns an EXPR_ERR that gets propagated upwards.
- */
-#define err SL_ERR
-
-/*
- * Show error message with `sl_print_ftl' and exit.
- */
-#define SL_FATAL(...)                                            \
-    do {                                                         \
-        sl_print_ftl(__FILE__, __LINE__, __func__, __VA_ARGS__); \
-        exit(1);                                                 \
-    } while (0)
-
-/*
- * If COND is zero, show error message and exit.
- */
-#define SL_ASSERT(COND)                                  \
-    do {                                                 \
-        if ((COND) == 0) {                               \
-            SL_FATAL("Assertion `%s' failed.\n", #COND); \
-        }                                                \
-    } while (0)
-
-/*
- * Set the instruction(s) to be executed when SL_EXPECT() fails.
- */
-#define SL_ON_ERR(INSTRUCTIONS) \
-    if (0) {                    \
-sl_lbl_on_err:                  \
-        INSTRUCTIONS;           \
-    }
-
-/*
- * If COND is not true, show warning and jump to instruction declared by
- * SL_ON_ERR().
- *
- * TODO: Instea of using SL_ON_ERR, return the EXPR_ERR returned by `err'.
- */
-#define SL_EXPECT(COND, ...)                                         \
-    do {                                                             \
-        if ((COND) == 0) {                                           \
-            err(__VA_ARGS__);                                        \
-            goto sl_lbl_on_err; /* Make sure you call SL_ON_ERR() */ \
-        }                                                            \
-    } while (0)
-
-/*
- * Check if the specified linked list of `Expr' structures has a specific
- * length using `SL_EXPECT'.
- *
- * TODO: This header is probably not the right place for this macro.
- */
-#define SL_EXPECT_ARG_NUM(EXPR_LIST, NUM)                    \
-    SL_EXPECT(expr_list_len(EXPR_LIST) == (NUM),             \
-              "Expected exactly %d arguments, got %d.", NUM, \
-              expr_list_len(EXPR_LIST))
-
-/*
- * Check if the specified expression matches the expected type using
- * `SL_EXPECT'.
- */
-#define SL_EXPECT_TYPE(EXPR, TYPE)                           \
-    SL_EXPECT((EXPR)->type == (TYPE),                        \
-              "Expected expression of type '%s', got '%s'.", \
-              exprtype2str(TYPE), exprtype2str((EXPR)->type))
 
 /*
  * Avoid -Wunused-parameter
@@ -128,16 +53,6 @@ sl_lbl_on_err:                  \
             SL_FATAL("Reallocation failed."); \
         }                                     \
     } while (0)
-
-/*----------------------------------------------------------------------------*/
-
-/*
- * Print different error messages to stderr, along with some context
- * information.
- */
-void sl_print_err(const char* func, const char* fmt, ...);
-void sl_print_ftl(const char* file, int line, const char* func, const char* fmt,
-                  ...);
 
 /*----------------------------------------------------------------------------*/
 

--- a/src/lambda.c
+++ b/src/lambda.c
@@ -221,8 +221,6 @@ void lambda_ctx_print_args(FILE* fp, const LambdaCtx* ctx) {
 /*----------------------------------------------------------------------------*/
 
 static Expr* lambda_ctx_eval_body(Env* env, LambdaCtx* ctx, Expr* args) {
-    SL_ON_ERR(return NULL);
-
     /* Count the number of arguments that we received */
     const size_t arg_num = expr_list_len(args);
 
@@ -273,8 +271,8 @@ static Expr* lambda_ctx_eval_body(Env* env, LambdaCtx* ctx, Expr* args) {
     for (Expr* cur = ctx->body; cur != NULL; cur = cur->next) {
         expr_free(last_evaluated);
         last_evaluated = eval(ctx->env, cur);
-        if (last_evaluated == NULL)
-            return NULL;
+        if (EXPRP_ERR(last_evaluated))
+            break;
     }
 
     return last_evaluated;
@@ -292,8 +290,8 @@ Expr* macro_expand(Env* env, Expr* func, Expr* args) {
 
 Expr* macro_call(Env* env, Expr* func, Expr* args) {
     Expr* expansion = macro_expand(env, func, args);
-    if (expansion == NULL)
-        return NULL;
+    if (EXPRP_ERR(expansion))
+        return expansion;
 
     /* Calling a macro is just evaluation its macro exansion */
     Expr* evaluated = eval(env, expansion);

--- a/src/lambda.c
+++ b/src/lambda.c
@@ -204,8 +204,9 @@ static Expr* lambda_ctx_eval_body(Env* env, LambdaCtx* ctx, Expr* args) {
      */
     Expr* cur_arg = args;
     for (size_t i = 0; i < ctx->formals_num && cur_arg != NULL; i++) {
-        if (!env_bind(ctx->env, ctx->formals[i], cur_arg, ENV_FLAG_NONE))
-            return NULL;
+        const bool bound =
+          env_bind(ctx->env, ctx->formals[i], cur_arg, ENV_FLAG_NONE);
+        SL_EXPECT(bound, "Could not bind symbol `%s'.", ctx->formals[i]);
 
         cur_arg = cur_arg->next;
     }
@@ -215,8 +216,9 @@ static Expr* lambda_ctx_eval_body(Env* env, LambdaCtx* ctx, Expr* args) {
         Expr* rest_list         = expr_new(EXPR_PARENT);
         rest_list->val.children = cur_arg;
 
-        if (!env_bind(ctx->env, ctx->formal_rest, rest_list, ENV_FLAG_NONE))
-            return NULL;
+        const bool bound =
+          env_bind(ctx->env, ctx->formal_rest, rest_list, ENV_FLAG_NONE);
+        SL_EXPECT(bound, "Could not bind symbol `%s'.", ctx->formal_rest);
 
         rest_list->val.children = NULL;
         expr_free(rest_list);

--- a/src/lambda.c
+++ b/src/lambda.c
@@ -26,23 +26,24 @@
 #include "include/util.h"
 #include "include/eval.h"
 
-/* Count and validate the number of formal arguments in a list */
-static bool count_formals(const Expr* list, size_t* mandatory, bool* has_rest) {
-    SL_ON_ERR(return false);
-
+/*
+ * Count and validate the number of formal arguments in a list. Returns
+ * LAMBDACTX_ERR_NONE on success.
+ */
+static enum ELambdaCtxErr count_formals(const Expr* list, size_t* mandatory,
+                                        bool* has_rest) {
     /* Initialize output variables */
     *mandatory = 0;
     *has_rest  = false;
 
     for (const Expr* cur = list; cur != NULL; cur = cur->next) {
-        SL_EXPECT(cur->type == EXPR_SYMBOL,
-                  "Invalid formal argument expected type 'Symbol', got '%s'.",
-                  exprtype2str(cur->type));
+        if (cur->type != EXPR_SYMBOL)
+            return LAMBDACTX_ERR_FORMALTYPE;
 
         /* Only a single formal can appear after "&rest" */
         if (strcmp(cur->val.s, "&rest") == 0) {
-            SL_EXPECT(cur->next != NULL && cur->next->next == NULL,
-                      "Expected exactly 1 formal after `&rest' keyword.");
+            if (cur->next == NULL || cur->next->next != NULL)
+                return LAMBDACTX_ERR_NOREST;
             *has_rest = true;
             break;
         }
@@ -50,20 +51,53 @@ static bool count_formals(const Expr* list, size_t* mandatory, bool* has_rest) {
         *mandatory += 1;
     }
 
-    return true;
+    return LAMBDACTX_ERR_NONE;
 }
 
-LambdaCtx* lambda_ctx_new(const Expr* formals, const Expr* body) {
+/*----------------------------------------------------------------------------*/
+
+const char* lambda_ctx_strerror(enum ELambdaCtxErr code) {
+    const char* s;
+    switch (code) {
+        case LAMBDACTX_ERR_NONE:
+            s = "No error.";
+            break;
+        case LAMBDACTX_ERR_FORMALTYPE:
+            s = "Invalid type for formal argument. Expected 'Symbol'.";
+            break;
+        case LAMBDACTX_ERR_NOREST:
+            s = "Exactly 1 formal must appear after `&rest' keyword.";
+            break;
+    }
+    return s;
+}
+
+/*----------------------------------------------------------------------------*/
+
+LambdaCtx* lambda_ctx_new(void) {
+    LambdaCtx* ret   = sl_safe_malloc(sizeof(LambdaCtx));
+    ret->env         = NULL;
+    ret->formals_num = 0;
+    ret->formals     = NULL;
+    ret->formal_rest = NULL;
+    ret->body        = NULL;
+    return ret;
+}
+
+enum ELambdaCtxErr lambda_ctx_init(LambdaCtx* ctx, const Expr* formals,
+                                   const Expr* body) {
     SL_ASSERT(formals->type == EXPR_PARENT);
 
     /* Count and validate the formal arguments */
     size_t mandatory;
     bool has_rest;
-    if (!count_formals(formals->val.children, &mandatory, &has_rest))
-        return NULL;
+    const enum ELambdaCtxErr formal_err =
+      count_formals(formals->val.children, &mandatory, &has_rest);
+    if (formal_err != LAMBDACTX_ERR_NONE)
+        return formal_err;
 
     /*
-     * Create a new LambdaCtx structure that will contain:
+     * Initialize the `LambdaCtx' structure with:
      *   - A new environment whose parent will be set when making the actual
      *     function call.
      *   - A string array for the formal arguments of the function, the first
@@ -74,12 +108,11 @@ LambdaCtx* lambda_ctx_new(const Expr* formals, const Expr* body) {
      * differently in `eval', we assume that the Lisp arguments were not
      * evaluated implicitly.
      */
-    LambdaCtx* ret   = sl_safe_malloc(sizeof(LambdaCtx));
-    ret->env         = env_new();
-    ret->formals_num = mandatory;
-    ret->formals     = sl_safe_malloc(mandatory * sizeof(char*));
-    ret->formal_rest = NULL;
-    ret->body        = expr_list_clone(body);
+    ctx->env         = env_new();
+    ctx->formals_num = mandatory;
+    ctx->formals     = sl_safe_malloc(mandatory * sizeof(char*));
+    ctx->formal_rest = NULL;
+    ctx->body        = expr_list_clone(body);
 
     /*
      * For each formal argument we counted above, store the symbol as a C string
@@ -88,17 +121,17 @@ LambdaCtx* lambda_ctx_new(const Expr* formals, const Expr* body) {
      */
     const Expr* cur_formal = formals->val.children;
     for (size_t i = 0; i < mandatory; i++) {
-        ret->formals[i] = strdup(cur_formal->val.s);
+        ctx->formals[i] = strdup(cur_formal->val.s);
         cur_formal      = cur_formal->next;
     }
 
     if (has_rest) {
         /* Skip "&rest" and save the symbol after it on the context */
         cur_formal       = cur_formal->next;
-        ret->formal_rest = strdup(cur_formal->val.s);
+        ctx->formal_rest = strdup(cur_formal->val.s);
     }
 
-    return ret;
+    return LAMBDACTX_ERR_NONE;
 }
 
 LambdaCtx* lambda_ctx_clone(const LambdaCtx* ctx) {

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -6,6 +6,7 @@
 #include <ctype.h>
 
 #include "include/util.h"
+#include "include/error.h"
 #include "include/lexer.h"
 
 #define TOKEN_BUFSZ  100

--- a/src/parser.c
+++ b/src/parser.c
@@ -43,7 +43,7 @@ static size_t wrap_in_call(Expr* dst, const Token* tokens,
      * The second element is the actual expression, which might consist of
      * multiple Tokens.
      */
-    dst->val.children->next     = expr_new(EXPR_ERR);
+    dst->val.children->next     = expr_new(EXPR_UNKNOWN);
     const size_t parsed_in_call = parse_recur(dst->val.children->next, tokens);
 
     SL_ASSERT(parsed_in_call > 0);
@@ -106,7 +106,7 @@ static size_t parse_recur(Expr* dst, const Token* tokens) {
                  * Parse the current children recursively, storing the parsed
                  * Tokens in that call.
                  */
-                cur_child->next = expr_new(EXPR_ERR);
+                cur_child->next = expr_new(EXPR_UNKNOWN);
                 const size_t parsed_in_call =
                   parse_recur(cur_child->next, &tokens[parsed]);
                 cur_child = cur_child->next;
@@ -187,7 +187,7 @@ Expr* parse(const Token* tokens) {
      * call is done parsing the list, we want to continue parsing at the "123",
      * not the "a".
      */
-    Expr* expr                 = expr_new(EXPR_ERR);
+    Expr* expr                 = expr_new(EXPR_UNKNOWN);
     const size_t tokens_parsed = parse_recur(expr, tokens);
     return (tokens_parsed == 0) ? NULL : expr;
 }

--- a/src/prim_arith.c
+++ b/src/prim_arith.c
@@ -26,7 +26,6 @@
 
 Expr* prim_add(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_ON_ERR(return NULL);
     SL_EXPECT(e == NULL || expr_list_has_only_numbers(e),
               "Unexpected non-numeric argument.");
 
@@ -74,7 +73,6 @@ Expr* prim_add(Env* env, Expr* e) {
 
 Expr* prim_sub(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_ON_ERR(return NULL);
     SL_EXPECT(e == NULL || expr_list_has_only_numbers(e),
               "Unexpected non-numeric argument.");
 
@@ -127,7 +125,6 @@ Expr* prim_sub(Env* env, Expr* e) {
 
 Expr* prim_mul(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_ON_ERR(return NULL);
     SL_EXPECT(e == NULL || expr_list_has_only_numbers(e),
               "Unexpected non-numeric argument.");
 
@@ -177,7 +174,6 @@ Expr* prim_mul(Env* env, Expr* e) {
 
 Expr* prim_div(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_ON_ERR(return NULL);
     SL_EXPECT(e != NULL, "Expected at least one argument.");
     SL_EXPECT(expr_list_has_only_numbers(e),
               "Unexpected non-numeric argument.");
@@ -200,7 +196,6 @@ Expr* prim_div(Env* env, Expr* e) {
 
 Expr* prim_mod(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_ON_ERR(return NULL);
     SL_EXPECT(e != NULL, "Expected at least one argument.");
     SL_EXPECT(expr_list_has_only_numbers(e),
               "Unexpected non-numeric argument.");
@@ -234,7 +229,6 @@ Expr* prim_mod(Env* env, Expr* e) {
 
 Expr* prim_quotient(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_ON_ERR(return NULL);
     SL_EXPECT(e != NULL, "Expected at least one argument.");
 
     /*
@@ -256,7 +250,6 @@ Expr* prim_quotient(Env* env, Expr* e) {
 
 Expr* prim_remainder(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_ON_ERR(return NULL);
     SL_EXPECT(e != NULL, "Missing arguments.");
 
     /*
@@ -281,7 +274,6 @@ Expr* prim_remainder(Env* env, Expr* e) {
 
 Expr* prim_round(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_ON_ERR(return NULL);
     SL_EXPECT_ARG_NUM(e, 1);
     SL_EXPECT(EXPRP_NUMBER(e), "Expected numeric argument.");
 
@@ -301,7 +293,6 @@ Expr* prim_round(Env* env, Expr* e) {
 
 Expr* prim_floor(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_ON_ERR(return NULL);
     SL_EXPECT_ARG_NUM(e, 1);
     SL_EXPECT(EXPRP_NUMBER(e), "Expected numeric argument.");
 
@@ -321,7 +312,6 @@ Expr* prim_floor(Env* env, Expr* e) {
 
 Expr* prim_ceiling(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_ON_ERR(return NULL);
     SL_EXPECT_ARG_NUM(e, 1);
     SL_EXPECT(EXPRP_NUMBER(e), "Expected numeric argument.");
 
@@ -341,7 +331,6 @@ Expr* prim_ceiling(Env* env, Expr* e) {
 
 Expr* prim_truncate(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_ON_ERR(return NULL);
     SL_EXPECT_ARG_NUM(e, 1);
     SL_EXPECT(EXPRP_NUMBER(e), "Expected numeric argument.");
 

--- a/src/prim_bitwise.c
+++ b/src/prim_bitwise.c
@@ -25,7 +25,6 @@
 
 Expr* prim_bit_and(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_ON_ERR(return NULL);
     SL_EXPECT(e != NULL, "Missing arguments.");
 
     long long total = e->val.n;
@@ -41,7 +40,6 @@ Expr* prim_bit_and(Env* env, Expr* e) {
 
 Expr* prim_bit_or(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_ON_ERR(return NULL);
     SL_EXPECT(e != NULL, "Missing arguments.");
 
     long long total = e->val.n;
@@ -57,7 +55,6 @@ Expr* prim_bit_or(Env* env, Expr* e) {
 
 Expr* prim_bit_xor(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_ON_ERR(return NULL);
     SL_EXPECT(e != NULL, "Missing arguments.");
 
     long long total = e->val.n;
@@ -73,7 +70,6 @@ Expr* prim_bit_xor(Env* env, Expr* e) {
 
 Expr* prim_bit_not(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_ON_ERR(return NULL);
     SL_EXPECT_ARG_NUM(e, 1);
     SL_EXPECT_TYPE(e, EXPR_NUM_INT);
 
@@ -84,7 +80,6 @@ Expr* prim_bit_not(Env* env, Expr* e) {
 
 Expr* prim_shr(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_ON_ERR(return NULL);
     SL_EXPECT_ARG_NUM(e, 2);
     SL_EXPECT_TYPE(e, EXPR_NUM_INT);
     SL_EXPECT_TYPE(e->next, EXPR_NUM_INT);
@@ -96,7 +91,6 @@ Expr* prim_shr(Env* env, Expr* e) {
 
 Expr* prim_shl(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_ON_ERR(return NULL);
     SL_EXPECT_ARG_NUM(e, 2);
     SL_EXPECT_TYPE(e, EXPR_NUM_INT);
     SL_EXPECT_TYPE(e->next, EXPR_NUM_INT);

--- a/src/prim_general.c
+++ b/src/prim_general.c
@@ -30,7 +30,6 @@ Expr* prim_eval(Env* env, Expr* e) {
 }
 
 Expr* prim_apply(Env* env, Expr* e) {
-    SL_ON_ERR(return NULL);
     SL_EXPECT_ARG_NUM(e, 2);
     SL_EXPECT(EXPRP_APPLICABLE(e),
               "Expected a function or macro as the first argument, got '%s'.",
@@ -41,7 +40,6 @@ Expr* prim_apply(Env* env, Expr* e) {
 }
 
 Expr* prim_macroexpand(Env* env, Expr* e) {
-    SL_ON_ERR(return NULL);
     SL_EXPECT_ARG_NUM(e, 1);
     SL_EXPECT_TYPE(e, EXPR_PARENT);
 
@@ -56,10 +54,9 @@ Expr* prim_macroexpand(Env* env, Expr* e) {
     SL_EXPECT(car != NULL,
               "The supplied list must have at least one element: The macro.");
 
-    /* If `eval' returns NULL, we don't have to print our own errors */
     Expr* func = eval(env, car);
-    if (func == NULL)
-        return NULL;
+    if (EXPRP_ERR(func))
+        return func;
     SL_EXPECT_TYPE(func, EXPR_MACRO);
 
     Expr* args     = e->val.children->next;
@@ -71,7 +68,6 @@ Expr* prim_macroexpand(Env* env, Expr* e) {
 
 Expr* prim_random(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_ON_ERR(return NULL);
     SL_EXPECT_ARG_NUM(e, 1);
     SL_EXPECT(EXPRP_NUMBER(e), "Expected numeric argument.");
 
@@ -100,7 +96,6 @@ Expr* prim_random(Env* env, Expr* e) {
 
 Expr* prim_set_random_seed(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_ON_ERR(return NULL);
     SL_EXPECT_ARG_NUM(e, 1);
     SL_EXPECT_TYPE(e, EXPR_NUM_INT);
 

--- a/src/prim_io.c
+++ b/src/prim_io.c
@@ -42,7 +42,6 @@ static bool is_char_in_str(char c, const char* str) {
 Expr* prim_read(Env* env, Expr* e) {
     SL_UNUSED(env);
     SL_UNUSED(e);
-    SL_ON_ERR(return NULL);
 
     char* str = read_expr(stdin);
     SL_EXPECT(str != NULL, "Error reading expression.");
@@ -58,7 +57,6 @@ Expr* prim_read(Env* env, Expr* e) {
 
 Expr* prim_write(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_ON_ERR(return NULL);
     SL_EXPECT_ARG_NUM(e, 1);
 
     const bool success = expr_write(stdout, e);
@@ -70,7 +68,6 @@ Expr* prim_write(Env* env, Expr* e) {
 
 Expr* prim_scan_str(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_ON_ERR(return NULL);
 
     /*
      * (scan-str &optional delimiters)
@@ -117,7 +114,6 @@ Expr* prim_scan_str(Env* env, Expr* e) {
 
 Expr* prim_print_str(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_ON_ERR(return NULL);
     SL_EXPECT_ARG_NUM(e, 1);
     SL_EXPECT_TYPE(e, EXPR_STRING);
 
@@ -127,12 +123,11 @@ Expr* prim_print_str(Env* env, Expr* e) {
 
 Expr* prim_error(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_ON_ERR(return NULL);
     SL_EXPECT_ARG_NUM(e, 1);
     SL_EXPECT_TYPE(e, EXPR_STRING);
 
-    sl_print_err(false, "error", "%s", e->val.s);
-
-    /* Intentionally return NULL to stop execution */
-    return NULL;
+    /*
+     * TODO: Use `prim_format' and `&rest'. Move outside of 'prim_io.c'.
+     */
+    return err("%s", e->val.s);
 }

--- a/src/prim_io.c
+++ b/src/prim_io.c
@@ -62,7 +62,10 @@ Expr* prim_write(Env* env, Expr* e) {
     SL_EXPECT_ARG_NUM(e, 1);
 
     const bool success = expr_write(stdout, e);
-    return (success) ? expr_clone(tru) : NULL;
+    SL_EXPECT(success, "Couldn't write expression of type '%s'.",
+              exprtype2str(e->type));
+
+    return expr_clone(tru);
 }
 
 Expr* prim_scan_str(Env* env, Expr* e) {

--- a/src/prim_list.c
+++ b/src/prim_list.c
@@ -96,7 +96,6 @@ Expr* prim_list(Env* env, Expr* e) {
 
 Expr* prim_cons(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_ON_ERR(return NULL);
     SL_EXPECT_ARG_NUM(e, 2);
     SL_EXPECT_TYPE(e->next, EXPR_PARENT);
 
@@ -115,7 +114,6 @@ Expr* prim_cons(Env* env, Expr* e) {
 
 Expr* prim_car(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_ON_ERR(return NULL);
     SL_EXPECT_ARG_NUM(e, 1);
     SL_EXPECT_TYPE(e, EXPR_PARENT);
 
@@ -132,7 +130,6 @@ Expr* prim_car(Env* env, Expr* e) {
 
 Expr* prim_cdr(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_ON_ERR(return NULL);
     SL_EXPECT_ARG_NUM(e, 1);
     SL_EXPECT_TYPE(e, EXPR_PARENT);
 
@@ -154,7 +151,6 @@ Expr* prim_cdr(Env* env, Expr* e) {
 
 Expr* prim_length(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_ON_ERR(return NULL);
     SL_EXPECT_ARG_NUM(e, 1);
 
     long long result;
@@ -168,8 +164,7 @@ Expr* prim_length(Env* env, Expr* e) {
             break;
 
         default:
-            err("Invalid argument of type '%s'.", exprtype2str(e->type));
-            return NULL;
+            return err("Invalid argument of type '%s'.", exprtype2str(e->type));
     }
 
     Expr* ret  = expr_new(EXPR_NUM_INT);
@@ -187,10 +182,8 @@ Expr* prim_append(Env* env, Expr* e) {
         return ret;
     }
 
-    if (!expr_list_is_homogeneous(e)) {
-        err("Expected arguments of the same type.");
-        return NULL;
-    }
+    if (!expr_list_is_homogeneous(e))
+        return err("Expected arguments of the same type.");
 
     Expr* ret;
     switch (e->type) {
@@ -211,8 +204,7 @@ Expr* prim_append(Env* env, Expr* e) {
             break;
 
         default:
-            err("Invalid argument of type '%s'.", exprtype2str(e->type));
-            ret = NULL;
+            ret = err("Invalid argument of type '%s'.", exprtype2str(e->type));
             break;
     }
 

--- a/src/prim_logic.c
+++ b/src/prim_logic.c
@@ -25,7 +25,6 @@
 
 Expr* prim_equal(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_ON_ERR(return NULL);
     SL_EXPECT(expr_list_len(e) >= 2, "Expected at least 2 arguments.");
 
     bool result = true;
@@ -43,7 +42,6 @@ Expr* prim_equal(Env* env, Expr* e) {
 
 Expr* prim_equal_num(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_ON_ERR(return NULL);
     SL_EXPECT(expr_list_len(e) >= 2, "Expected at least 2 arguments.");
 
     bool result = true;
@@ -62,7 +60,6 @@ Expr* prim_equal_num(Env* env, Expr* e) {
 
 Expr* prim_lt(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_ON_ERR(return NULL);
     SL_EXPECT(expr_list_len(e) >= 2, "Expected at least 2 arguments.");
 
     bool result = true;
@@ -80,7 +77,6 @@ Expr* prim_lt(Env* env, Expr* e) {
 
 Expr* prim_gt(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_ON_ERR(return NULL);
     SL_EXPECT(expr_list_len(e) >= 2, "Expected at least 2 arguments.");
 
     bool result = true;

--- a/src/prim_special.c
+++ b/src/prim_special.c
@@ -232,12 +232,15 @@ Expr* prim_lambda(Env* env, Expr* e) {
      * the body expressions we received. Store that context structure in the
      * expression we will return.
      */
-    Expr* ret = expr_new(EXPR_LAMBDA);
 
-    const Expr* formals = e;
-    const Expr* body    = e->next;
-    ret->val.lambda     = lambda_ctx_new(formals, body);
+    const Expr* formals   = e;
+    const Expr* body      = e->next;
+    LambdaCtx* lambda_ctx = lambda_ctx_new(formals, body);
+    if (lambda_ctx == NULL)
+        return NULL;
 
+    Expr* ret       = expr_new(EXPR_LAMBDA);
+    ret->val.lambda = lambda_ctx;
     return ret;
 }
 
@@ -249,16 +252,18 @@ Expr* prim_macro(Env* env, Expr* e) {
               "and body.");
     SL_EXPECT_TYPE(e, EXPR_PARENT);
 
+    const Expr* formals   = e;
+    const Expr* body      = e->next;
+    LambdaCtx* lambda_ctx = lambda_ctx_new(formals, body);
+    if (lambda_ctx == NULL)
+        return NULL;
+
     /*
      * The `macro' and `lambda' primitives are identical, but the type of the
      * returned expression changes.
      */
-    Expr* ret = expr_new(EXPR_MACRO);
-
-    const Expr* formals = e;
-    const Expr* body    = e->next;
-    ret->val.lambda     = lambda_ctx_new(formals, body);
-
+    Expr* ret       = expr_new(EXPR_MACRO);
+    ret->val.lambda = lambda_ctx;
     return ret;
 }
 

--- a/src/prim_special.c
+++ b/src/prim_special.c
@@ -188,8 +188,10 @@ Expr* prim_define(Env* env, Expr* e) {
     if (evaluated == NULL)
         return NULL;
 
-    const bool success = env_bind(env, e->val.s, evaluated, ENV_FLAG_NONE);
-    return (success) ? evaluated : NULL;
+    const bool bound = env_bind(env, e->val.s, evaluated, ENV_FLAG_NONE);
+    SL_EXPECT(bound, "Could not bind symbol `%s'.", e->val.s);
+
+    return evaluated;
 }
 
 Expr* prim_define_global(Env* env, Expr* e) {

--- a/src/prim_string.c
+++ b/src/prim_string.c
@@ -40,6 +40,7 @@ Expr* prim_write_to_str(Env* env, Expr* e) {
 
     if (!success) {
         free(str);
+        err("Couldn't write expression of type '%s'.", exprtype2str(e->type));
         return NULL;
     }
 

--- a/src/prim_string.c
+++ b/src/prim_string.c
@@ -98,7 +98,7 @@ Expr* prim_format(Env* env, Expr* e) {
          * expression type of the value.
          */
         const char* c_format     = NULL;
-        enum EExprType expr_type = EXPR_ERR;
+        enum EExprType expr_type = EXPR_UNKNOWN;
         switch (*fmt) {
             case 's':
                 c_format  = "%s";

--- a/src/prim_string.c
+++ b/src/prim_string.c
@@ -28,7 +28,6 @@
 
 Expr* prim_write_to_str(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_ON_ERR(return NULL);
     SL_EXPECT_ARG_NUM(e, 1);
 
     char* str;
@@ -40,8 +39,8 @@ Expr* prim_write_to_str(Env* env, Expr* e) {
 
     if (!success) {
         free(str);
-        err("Couldn't write expression of type '%s'.", exprtype2str(e->type));
-        return NULL;
+        return err("Couldn't write expression of type '%s'.",
+                   exprtype2str(e->type));
     }
 
     Expr* ret  = expr_new(EXPR_STRING);
@@ -59,7 +58,6 @@ Expr* prim_write_to_str(Env* env, Expr* e) {
 
 Expr* prim_format(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_ON_ERR(return NULL);
     SL_EXPECT(e != NULL, "Missing arguments.");
     SL_EXPECT_TYPE(e, EXPR_STRING);
 
@@ -89,9 +87,8 @@ Expr* prim_format(Env* env, Expr* e) {
 
         /* Make sure the user supplied enough arguments. */
         if (cur_arg == NULL) {
-            err("Not enough arguments for the specified format.");
             free(dst);
-            return NULL;
+            return err("Not enough arguments for the specified format.");
         }
 
         /*
@@ -134,7 +131,8 @@ Expr* prim_format(Env* env, Expr* e) {
                 goto done;
 
             default:
-                err("Invalid format specifier: '%c' (0x%02x).", *fmt, *fmt);
+                /* Just print a warning, but don't stop */
+                SL_ERR("Invalid format specifier: '%c' (0x%02x).", *fmt, *fmt);
                 dst[dst_pos++] = *fmt++;
                 continue;
         }
@@ -145,10 +143,10 @@ Expr* prim_format(Env* env, Expr* e) {
          * argument.
          */
         if (expr_type != cur_arg->type) {
-            err("Format specifier expected argument of type '%s', got '%s'.",
-                exprtype2str(expr_type), exprtype2str(cur_arg->type));
             free(dst);
-            return NULL;
+            return err("Format specifier expected argument of type '%s', got "
+                       "'%s'.",
+                       exprtype2str(expr_type), exprtype2str(cur_arg->type));
         }
 
         /*
@@ -197,7 +195,6 @@ done:
 
 Expr* prim_substring(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_ON_ERR(return NULL);
 
     const size_t arg_num = expr_list_len(e);
     SL_EXPECT(arg_num >= 1 || arg_num <= 3,
@@ -250,7 +247,6 @@ Expr* prim_substring(Env* env, Expr* e) {
 
 Expr* prim_re_match_groups(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_ON_ERR(return NULL);
 
     const size_t arg_num = expr_list_len(e);
     SL_EXPECT(arg_num >= 2 || arg_num <= 3, "Expected 2 or 3 arguments.");

--- a/src/prim_type.c
+++ b/src/prim_type.c
@@ -121,8 +121,8 @@ Expr* prim_int2str(Env* env, Expr* e) {
     SL_EXPECT_TYPE(e, EXPR_NUM_INT);
 
     char* s;
-    if (int2str(e->val.n, &s) == 0)
-        return NULL;
+    const size_t written = int2str(e->val.n, &s);
+    SL_EXPECT(written > 0, "Failed to convert Integer to String.");
 
     Expr* ret  = expr_new(EXPR_STRING);
     ret->val.s = s;
@@ -136,8 +136,8 @@ Expr* prim_flt2str(Env* env, Expr* e) {
     SL_EXPECT_TYPE(e, EXPR_NUM_FLT);
 
     char* s;
-    if (flt2str(e->val.f, &s) == 0)
-        return NULL;
+    const size_t written = flt2str(e->val.f, &s);
+    SL_EXPECT(written > 0, "Failed to convert Float to String.");
 
     Expr* ret  = expr_new(EXPR_STRING);
     ret->val.s = s;

--- a/src/prim_type.c
+++ b/src/prim_type.c
@@ -29,7 +29,6 @@
 
 Expr* prim_type_of(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_ON_ERR(return NULL);
     SL_EXPECT_ARG_NUM(e, 1);
 
     Expr* ret  = expr_new(EXPR_SYMBOL);
@@ -90,7 +89,6 @@ Expr* prim_is_macro(Env* env, Expr* e) {
 
 Expr* prim_int2flt(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_ON_ERR(return NULL);
     SL_EXPECT_ARG_NUM(e, 1);
     SL_EXPECT_TYPE(e, EXPR_NUM_INT);
 
@@ -101,7 +99,6 @@ Expr* prim_int2flt(Env* env, Expr* e) {
 
 Expr* prim_flt2int(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_ON_ERR(return NULL);
     SL_EXPECT_ARG_NUM(e, 1);
     SL_EXPECT_TYPE(e, EXPR_NUM_FLT);
 
@@ -116,7 +113,6 @@ Expr* prim_flt2int(Env* env, Expr* e) {
  */
 Expr* prim_int2str(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_ON_ERR(return NULL);
     SL_EXPECT_ARG_NUM(e, 1);
     SL_EXPECT_TYPE(e, EXPR_NUM_INT);
 
@@ -131,7 +127,6 @@ Expr* prim_int2str(Env* env, Expr* e) {
 
 Expr* prim_flt2str(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_ON_ERR(return NULL);
     SL_EXPECT_ARG_NUM(e, 1);
     SL_EXPECT_TYPE(e, EXPR_NUM_FLT);
 
@@ -146,7 +141,6 @@ Expr* prim_flt2str(Env* env, Expr* e) {
 
 Expr* prim_str2int(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_ON_ERR(return NULL);
     SL_EXPECT_ARG_NUM(e, 1);
     SL_EXPECT_TYPE(e, EXPR_STRING);
 
@@ -157,7 +151,6 @@ Expr* prim_str2int(Env* env, Expr* e) {
 
 Expr* prim_str2flt(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_ON_ERR(return NULL);
     SL_EXPECT_ARG_NUM(e, 1);
     SL_EXPECT_TYPE(e, EXPR_STRING);
 

--- a/src/read.c
+++ b/src/read.c
@@ -26,6 +26,7 @@
 #include <ctype.h>
 
 #include "include/util.h"
+#include "include/error.h"
 #include "include/read.h"
 #include "include/lexer.h" /* is_token_separator() */
 

--- a/src/util.c
+++ b/src/util.c
@@ -25,53 +25,7 @@
 #include <regex.h>
 
 #include "include/util.h"
-
-#define COL_RESET       "\e[0m"
-#define COL_NORM_YELLOW "\e[0;33m"
-#define COL_NORM_RED    "\e[0;31m"
-#define COL_BOLD_CYAN   "\e[1;36m"
-#define COL_BOLD_RED    "\e[1;31m"
-
-void sl_print_err(const char* func, const char* fmt, ...) {
-    va_list va;
-    va_start(va, fmt);
-
-#ifdef SL_NO_COLOR
-    fprintf(stderr, "%s: ", func);
-    vfprintf(stderr, fmt, va);
-#else
-    fprintf(stderr, "%s%s%s: %s", COL_BOLD_CYAN, func, COL_RESET,
-            COL_NORM_YELLOW);
-    vfprintf(stderr, fmt, va);
-    fprintf(stderr, "%s", COL_RESET);
-#endif
-
-    fputc('\n', stderr);
-
-    va_end(va);
-}
-
-void sl_print_ftl(const char* file, int line, const char* func, const char* fmt,
-                  ...) {
-    va_list va;
-    va_start(va, fmt);
-
-#ifdef SL_NO_COLOR
-    fprintf(stderr, "%s:%d: %s: ", file, line, func);
-    vfprintf(stderr, fmt, va);
-#else
-    fprintf(stderr, "%s:%d: %s%s%s: %s", file, line, COL_BOLD_CYAN, func,
-            COL_RESET, COL_NORM_RED);
-    vfprintf(stderr, fmt, va);
-    fprintf(stderr, "%s", COL_RESET);
-#endif
-
-    fputc('\n', stderr);
-
-    va_end(va);
-}
-
-/*----------------------------------------------------------------------------*/
+#include "include/error.h"
 
 void* sl_safe_malloc(size_t size) {
     void* result = malloc(size);

--- a/src/util.c
+++ b/src/util.c
@@ -179,7 +179,6 @@ size_t int2str(long long x, char** dst) {
      */
     const int size = snprintf(NULL, 0, "%lld", x);
     if (size < 0) {
-        SL_ERR("Failed to get the target string length for integer: %lld", x);
         *dst = NULL;
         return 0;
     }
@@ -192,7 +191,6 @@ size_t int2str(long long x, char** dst) {
 size_t flt2str(double x, char** dst) {
     const int size = snprintf(NULL, 0, "%f", x);
     if (size < 0) {
-        SL_ERR("Failed to get the target string length for float: %f", x);
         *dst = NULL;
         return 0;
     }


### PR DESCRIPTION
Changes:
- Move error functions from util.c to error.c
- Turn `err` into a function, defined in "error.c".
- Add expression of type *Unknown*.
- Remove `SL_ON_ERR` macro.
- Allow NULL as argument to `env_free`.
- Use bit shift syntax for EExprType enum.
- Add `ELambdaCtxErr` enum. They can be converted to readable strings with the
  `lambda_ctx_strerror` function.
- Split `lambda_ctx_new` into `lambda_ctx_init`.
- The `lambda_ctx_init` function returns an error code, and doesn't print
  anything.
- Print errors in `prim_lambda` or `prim_macro`.
- Don't print error messages in many functions that shouldn't be messing with
  I/O.

This pull request might have introduced some bugs. It's specially difficult to test every edge case since there are a lot of possible errors that would need to be tested.

