### PR TITLE
Cons pair support

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -39,20 +39,22 @@ bool debug_is_traced_function(const Env* env, const Expr* e) {
      * from a C list, and somehow allow the user to add items to it.
      */
     Expr* debug_trace_list = env_get(env, "*debug-trace*");
-    if (debug_trace_list == NULL || debug_trace_list->type != EXPR_PARENT)
+    if (debug_trace_list == NULL || expr_is_proper_list(debug_trace_list))
         return false;
 
-    return expr_list_is_member(debug_trace_list->val.children, e);
+    return expr_is_member(debug_trace_list, e);
 }
 
 void debug_trace_print_pre(FILE* fp, const Expr* func, const Expr* arg) {
+    SL_ASSERT(expr_is_proper_list(arg));
+
     print_trace_number(fp);
 
     fputc('(', fp);
     expr_print(fp, func);
-    for (; arg != NULL; arg = arg->next) {
+    for (; !expr_is_nil(arg); arg = CDR(arg)) {
         fputc(' ', fp);
-        expr_print(fp, arg);
+        expr_print(fp, CAR(arg));
     }
     fprintf(fp, ")\n");
 

--- a/src/env.c
+++ b/src/env.c
@@ -65,16 +65,15 @@ void env_init_defaults(Env* env) {
      * to the environment.
      */
     if (g_nil == NULL) {
-        g_nil               = expr_new(EXPR_PARENT);
-        g_nil->val.children = NULL;
+        g_nil        = expr_new(EXPR_SYMBOL);
+        g_nil->val.s = mem_strdup("nil");
     }
     if (g_tru == NULL) {
         g_tru        = expr_new(EXPR_SYMBOL);
         g_tru->val.s = mem_strdup("tru");
     }
     if (g_debug_trace_list == NULL) {
-        g_debug_trace_list               = expr_new(EXPR_PARENT);
-        g_debug_trace_list->val.children = NULL;
+        g_debug_trace_list = expr_clone(g_nil);
     }
     SL_ASSERT(env_bind(env, "nil", g_nil, ENV_FLAG_CONST) == ENV_ERR_NONE);
     SL_ASSERT(env_bind(env, "tru", g_tru, ENV_FLAG_CONST) == ENV_ERR_NONE);
@@ -114,7 +113,7 @@ void env_init_defaults(Env* env) {
     BIND_PRIM(env, "flt?", is_flt);
     BIND_PRIM(env, "symbol?", is_symbol);
     BIND_PRIM(env, "string?", is_string);
-    BIND_PRIM(env, "list?", is_list);
+    BIND_PRIM(env, "pair?", is_pair);
     BIND_PRIM(env, "primitive?", is_primitive);
     BIND_PRIM(env, "lambda?", is_lambda);
     BIND_PRIM(env, "macro?", is_macro);

--- a/src/expr.c
+++ b/src/expr.c
@@ -241,81 +241,81 @@ bool expr_is_proper_list(const Expr* e) {
     return true;
 }
 
-size_t expr_list_len(const Expr* e) {
-    SL_ASSERT(e != NULL);
-    SL_ASSERT(expr_is_proper_list(e));
+size_t expr_list_len(const Expr* list) {
+    SL_ASSERT(list != NULL);
+    SL_ASSERT(expr_is_proper_list(list));
 
     size_t result = 0;
-    for (; !expr_is_nil(e); e = CDR(e))
+    for (; !expr_is_nil(list); list = CDR(list))
         result++;
     return result;
 }
 
-Expr* expr_list_nth(const Expr* e, size_t n) {
-    SL_ASSERT(e != NULL);
-    SL_ASSERT(n > 0 && n <= expr_list_len(e));
+Expr* expr_list_nth(const Expr* list, size_t n) {
+    SL_ASSERT(list != NULL);
+    SL_ASSERT(n > 0 && n <= expr_list_len(list));
 
     while (--n > 0)
-        e = CDR(e);
+        list = CDR(list);
 
-    return CAR(e);
+    return CAR(list);
 }
 
-bool expr_is_member(const Expr* lst, const Expr* e) {
-    SL_ASSERT(lst != NULL && e != NULL);
-    SL_ASSERT(expr_is_proper_list(lst));
+bool expr_is_member(const Expr* list, const Expr* e) {
+    SL_ASSERT(list != NULL && e != NULL);
+    SL_ASSERT(expr_is_proper_list(list));
 
-    for (; !expr_is_nil(lst); lst = CDR(lst))
-        if (expr_equal(CAR(lst), e))
+    for (; !expr_is_nil(list); list = CDR(list))
+        if (expr_equal(CAR(list), e))
             return true;
 
     return false;
 }
 
-bool expr_list_is_homogeneous(const Expr* e) {
-    SL_ASSERT(e != NULL);
-    SL_ASSERT(expr_is_proper_list(e));
+bool expr_list_is_homogeneous(const Expr* list) {
+    SL_ASSERT(list != NULL);
+    SL_ASSERT(expr_is_proper_list(list));
 
     /*
      * Store the type of the first element, and start checking from the second
      * one.
      */
-    const enum EExprType first_type = CAR(e)->type;
-    for (e = CDR(e); !expr_is_nil(e); e = CDR(e))
-        if (CAR(e)->type != first_type)
+    const enum EExprType first_type = CAR(list)->type;
+    for (list = CDR(list); !expr_is_nil(list); list = CDR(list))
+        if (CAR(list)->type != first_type)
             return false;
 
     return true;
 }
 
-bool expr_list_has_type(const Expr* e, enum EExprType type) {
-    SL_ASSERT(e != NULL);
-    SL_ASSERT(expr_is_proper_list(e));
+bool expr_list_has_type(const Expr* list, enum EExprType type) {
+    SL_ASSERT(list != NULL);
+    SL_ASSERT(expr_is_proper_list(list));
 
-    for (; !expr_is_nil(e); e = CDR(e))
-        if (CAR(e)->type == type)
+    for (; !expr_is_nil(list); list = CDR(list))
+        if (CAR(list)->type == type)
             return true;
 
     return false;
 }
 
-bool expr_list_has_only_numbers(const Expr* e) {
-    SL_ASSERT(e != NULL);
-    SL_ASSERT(expr_is_proper_list(e));
+bool expr_list_has_only_numbers(const Expr* list) {
+    SL_ASSERT(list != NULL);
+    SL_ASSERT(expr_is_proper_list(list));
 
-    for (; !expr_is_nil(e); e = CDR(e))
-        if (!EXPR_NUMBER_P(CAR(e)))
+    for (; !expr_is_nil(list); list = CDR(list))
+        if (!EXPR_NUMBER_P(CAR(list)))
             return false;
 
     return true;
 }
 
-bool expr_list_has_only_lists(const Expr* e) {
-    SL_ASSERT(e != NULL);
-    SL_ASSERT(expr_is_proper_list(e));
+bool expr_list_has_only_lists(const Expr* list) {
+    SL_ASSERT(list != NULL);
+    SL_ASSERT(expr_is_proper_list(list));
 
-    for (; !expr_is_nil(e); e = CDR(e))
-        if (!expr_is_proper_list(CAR(e)))
+    for (; !expr_is_nil(list); list = CDR(list))
+        if (!expr_is_proper_list(CAR(list)))
             return false;
 
     return true;

--- a/src/expr_pool.c
+++ b/src/expr_pool.c
@@ -90,7 +90,7 @@ static void free_heap_expr_members(Expr* e) {
         case EXPR_NUM_INT:
         case EXPR_NUM_FLT:
         case EXPR_PRIM:
-        case EXPR_PARENT:
+        case EXPR_PAIR:
             break;
     }
 }

--- a/src/include/error.h
+++ b/src/include/error.h
@@ -77,8 +77,11 @@ struct Expr; /* expr.h */
     } while (0)
 
 /*
- * Check if the specified linked list of 'Expr' structures has a specific
+ * Check if the specified list of 'Expr' structures has a specific
  * length using 'SL_EXPECT'.
+ *
+ * TODO: Add 'SL_EXPECT_LEN' macro, use when the list is not an argument list.
+ * TODO: Rename arguments of primitives to 'args', rather than 'e'.
  */
 #define SL_EXPECT_ARG_NUM(EXPR_LIST, NUM)                                      \
     SL_EXPECT(expr_list_len(EXPR_LIST) == (NUM),                               \
@@ -94,6 +97,11 @@ struct Expr; /* expr.h */
     SL_EXPECT((EXPR)->type == (TYPE),                                          \
               "Expected expression of type '%s', got '%s'.",                   \
               exprtype2str(TYPE),                                              \
+              exprtype2str((EXPR)->type))
+
+#define SL_EXPECT_PROPER_LIST(EXPR)                                            \
+    SL_EXPECT(expr_is_proper_list(EXPR),                                       \
+              "Expected a proper list, got '%s'.",                             \
               exprtype2str((EXPR)->type))
 
 /*----------------------------------------------------------------------------*/

--- a/src/include/expr.h
+++ b/src/include/expr.h
@@ -194,7 +194,7 @@ bool expr_is_proper_list(const Expr* e);
 /*
  * Count the number of elements the specified list.
  */
-size_t expr_list_len(const Expr* e);
+size_t expr_list_len(const Expr* list);
 
 /*
  * Return a pointer to the N-th element of the specified list. The returned
@@ -203,7 +203,7 @@ size_t expr_list_len(const Expr* e);
  * The 'n' argument is supposed to be one-indexed and smaller than the size of
  * the list (according to 'expr_list_len'), or an assertion will fail.
  */
-Expr* expr_list_nth(const Expr* e, size_t n);
+Expr* expr_list_nth(const Expr* list, size_t n);
 
 /*
  * Does the specified list contain the specified expression? The check is
@@ -214,38 +214,39 @@ Expr* expr_list_nth(const Expr* e, size_t n);
  * `member'. Make 'expr_is_member' inline for checking if it returned NULL or
  * not.
  */
-bool expr_is_member(const Expr* lst, const Expr* e);
+bool expr_is_member(const Expr* list, const Expr* e);
 
 /*
  * Is the specified list homogeneous? In other words, do all elements share the
  * same type?
  */
-bool expr_list_is_homogeneous(const Expr* e);
+bool expr_list_is_homogeneous(const Expr* list);
 
 /*
  * Does the specified list contain at least one expression with the specified
  * type?
  */
-bool expr_list_has_type(const Expr* e, enum EExprType type);
+bool expr_list_has_type(const Expr* list, enum EExprType type);
 
 /*
  * Does the specified list contain ONLY expressions with numeric types? Uses the
  * 'EXPR_NUMBER_P' macro, defined above.
  */
-bool expr_list_has_only_numbers(const Expr* e);
+bool expr_list_has_only_numbers(const Expr* list);
 
 /*
  * Does the specified list contain ONLY proper lists? Uses the
  * 'expr_is_proper_list' function.
  */
-bool expr_list_has_only_lists(const Expr* e);
+bool expr_list_has_only_lists(const Expr* list);
 
 /*
  * Does the specified linked list contain ONLY expressions with the specified
  * type?
  */
-static inline bool expr_list_has_only_type(const Expr* e, enum EExprType type) {
-    return expr_list_is_homogeneous(e) && CAR(e)->type == type;
+static inline bool expr_list_has_only_type(const Expr* list,
+                                           enum EExprType type) {
+    return expr_list_is_homogeneous(list) && CAR(list)->type == type;
 }
 
 /*----------------------------------------------------------------------------*/

--- a/src/include/lexer.h
+++ b/src/include/lexer.h
@@ -41,6 +41,7 @@ enum ETokenType {
      */
     TOKEN_LIST_OPEN,
     TOKEN_LIST_CLOSE,
+    TOKEN_DOT,
 
     /*
      * Indicates that the next expression should be wrapped in (quote ...),

--- a/src/include/primitives.h
+++ b/src/include/primitives.h
@@ -57,7 +57,7 @@ DECLARE_PRIM(is_int);
 DECLARE_PRIM(is_flt);
 DECLARE_PRIM(is_symbol);
 DECLARE_PRIM(is_string);
-DECLARE_PRIM(is_list);
+DECLARE_PRIM(is_pair);
 DECLARE_PRIM(is_primitive);
 DECLARE_PRIM(is_lambda);
 DECLARE_PRIM(is_macro);

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -113,6 +113,11 @@ static Token get_token(char** input_ptr) {
             input++;
             goto done;
 
+        case '.':
+            result.type = TOKEN_DOT;
+            input++;
+            goto done;
+
         case '\'':
             result.type = TOKEN_QUOTE;
             input++;
@@ -234,6 +239,10 @@ void tokens_print(FILE* fp, Token* arr) {
 
             case TOKEN_LIST_CLOSE:
                 fprintf(fp, "LIST_CLOSE, ");
+                break;
+
+            case TOKEN_DOT:
+                fprintf(fp, "DOT, ");
                 break;
 
             case TOKEN_QUOTE:

--- a/src/parser.c
+++ b/src/parser.c
@@ -31,6 +31,10 @@
 
 static size_t parse_recur(Expr* dst, const Token* tokens);
 
+static inline bool is_list_closer(enum ETokenType token_type) {
+    return token_type == TOKEN_LIST_CLOSE || token_type == TOKEN_EOF;
+}
+
 /*
  * Parse the next expression in 'tokens', and wrap it in a list whose first
  * element is the symbol 'func_name'. Return the number of parsed tokens.
@@ -106,8 +110,7 @@ static size_t parse_recur(Expr* dst, const Token* tokens) {
             /*
              * Empty lists get replaced by the symbol "nil" in the parser.
              */
-            if (tokens[parsed].type == TOKEN_LIST_CLOSE ||
-                tokens[parsed].type == TOKEN_EOF) {
+            if (is_list_closer(tokens[parsed].type)) {
                 dst->type  = EXPR_SYMBOL;
                 dst->val.s = mem_strdup("nil");
                 parsed++;
@@ -126,8 +129,7 @@ static size_t parse_recur(Expr* dst, const Token* tokens) {
             parsed += parsed_in_call;
 
             Expr* cur = dst;
-            while (tokens[parsed].type != TOKEN_LIST_CLOSE &&
-                   tokens[parsed].type != TOKEN_EOF) {
+            while (!is_list_closer(tokens[parsed].type)) {
                 /*
                  * TODO: Add TOKEN_DOT to lexer.
                  * TODO: Allow dot inside lists to indicate that the following

--- a/src/prim_arith.c
+++ b/src/prim_arith.c
@@ -26,8 +26,12 @@
 
 Expr* prim_add(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_EXPECT(e == NULL || expr_list_has_only_numbers(e),
+
+    const bool no_args = expr_is_nil(e);
+    SL_EXPECT(no_args || expr_list_has_only_numbers(e),
               "Unexpected non-numeric argument.");
+
+    const Expr* first_arg = CAR(e);
 
     /*
      * If there are no arguments, return zero.
@@ -40,32 +44,32 @@ Expr* prim_add(Env* env, Expr* e) {
      *   (+ 9.0 5.0 1.0) => 15.0
      */
     Expr* ret;
-    if (e == NULL) {
+    if (no_args) {
         ret        = expr_new(EXPR_NUM_INT);
         ret->val.n = 0;
     } else if (!expr_list_is_homogeneous(e)) {
-        GenericNum total = expr_get_generic_num(e);
-        for (Expr* arg = e->next; arg != NULL; arg = arg->next)
-            total += expr_get_generic_num(arg);
+        GenericNum total = 0;
+        for (; !expr_is_nil(e); e = CDR(e))
+            total += expr_get_generic_num(CAR(e));
 
         ret = expr_new(EXPR_NUM_GENERIC);
         expr_set_generic_num(ret, total);
-    } else if (e->type == EXPR_NUM_INT) {
-        LispInt total = e->val.n;
-        for (Expr* arg = e->next; arg != NULL; arg = arg->next)
-            total += arg->val.n;
+    } else if (first_arg->type == EXPR_NUM_INT) {
+        LispInt total = 0;
+        for (; !expr_is_nil(e); e = CDR(e))
+            total += CAR(e)->val.n;
 
         ret        = expr_new(EXPR_NUM_INT);
         ret->val.n = total;
-    } else if (e->type == EXPR_NUM_FLT) {
-        LispFlt total = e->val.f;
-        for (Expr* arg = e->next; arg != NULL; arg = arg->next)
-            total += arg->val.f;
+    } else if (first_arg->type == EXPR_NUM_FLT) {
+        LispFlt total = 0.0;
+        for (; !expr_is_nil(e); e = CDR(e))
+            total += CAR(e)->val.f;
 
         ret        = expr_new(EXPR_NUM_FLT);
         ret->val.f = total;
     } else {
-        SL_FATAL("Unhandled numeric type (%s).", exprtype2str(e->type));
+        SL_FATAL("Unhandled numeric type (%s).", exprtype2str(first_arg->type));
     }
 
     return ret;
@@ -73,8 +77,12 @@ Expr* prim_add(Env* env, Expr* e) {
 
 Expr* prim_sub(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_EXPECT(e == NULL || expr_list_has_only_numbers(e),
+
+    const bool no_args = expr_is_nil(e);
+    SL_EXPECT(no_args || expr_list_has_only_numbers(e),
               "Unexpected non-numeric argument.");
+
+    const Expr* first_arg = CAR(e);
 
     /*
      * If there are no arguments, return zero.
@@ -89,35 +97,35 @@ Expr* prim_sub(Env* env, Expr* e) {
      *   (- 9.0 5.0 1.0) => 3.0
      */
     Expr* ret;
-    if (e == NULL) {
+    if (no_args) {
         ret        = expr_new(EXPR_NUM_INT);
         ret->val.n = 0;
-    } else if (e->next == NULL) {
-        ret = expr_clone(e);
+    } else if (expr_is_nil(CDR(e))) {
+        ret = expr_clone(first_arg);
         expr_negate_num_val(ret);
     } else if (!expr_list_is_homogeneous(e)) {
-        GenericNum total = expr_get_generic_num(e);
-        for (Expr* arg = e->next; arg != NULL; arg = arg->next)
-            total -= expr_get_generic_num(arg);
+        GenericNum total = expr_get_generic_num(first_arg);
+        for (e = CDR(e); !expr_is_nil(e); e = CDR(e))
+            total -= expr_get_generic_num(CAR(e));
 
         ret = expr_new(EXPR_NUM_GENERIC);
         expr_set_generic_num(ret, total);
-    } else if (e->type == EXPR_NUM_INT) {
-        LispInt total = e->val.n;
-        for (Expr* arg = e->next; arg != NULL; arg = arg->next)
-            total -= arg->val.n;
+    } else if (first_arg->type == EXPR_NUM_INT) {
+        LispInt total = first_arg->val.n;
+        for (e = CDR(e); !expr_is_nil(e); e = CDR(e))
+            total -= CAR(e)->val.n;
 
         ret        = expr_new(EXPR_NUM_INT);
         ret->val.n = total;
-    } else if (e->type == EXPR_NUM_FLT) {
-        LispFlt total = e->val.f;
-        for (Expr* arg = e->next; arg != NULL; arg = arg->next)
-            total -= arg->val.f;
+    } else if (first_arg->type == EXPR_NUM_FLT) {
+        LispFlt total = first_arg->val.f;
+        for (e = CDR(e); !expr_is_nil(e); e = CDR(e))
+            total -= CAR(e)->val.f;
 
         ret        = expr_new(EXPR_NUM_FLT);
         ret->val.f = total;
     } else {
-        SL_FATAL("Unhandled numeric type (%s).", exprtype2str(e->type));
+        SL_FATAL("Unhandled numeric type (%s).", exprtype2str(first_arg->type));
     }
 
     return ret;
@@ -125,8 +133,12 @@ Expr* prim_sub(Env* env, Expr* e) {
 
 Expr* prim_mul(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_EXPECT(e == NULL || expr_list_has_only_numbers(e),
+
+    const bool no_args = expr_is_nil(e);
+    SL_EXPECT(no_args || expr_list_has_only_numbers(e),
               "Unexpected non-numeric argument.");
+
+    const Expr* first_arg = CAR(e);
 
     /*
      * If there are no arguments, return one.
@@ -141,32 +153,32 @@ Expr* prim_mul(Env* env, Expr* e) {
      *   (* 9.0 5.0 1.0) => 3.0
      */
     Expr* ret;
-    if (e == NULL) {
+    if (no_args) {
         ret        = expr_new(EXPR_NUM_INT);
         ret->val.n = 1;
     } else if (!expr_list_is_homogeneous(e)) {
-        GenericNum total = expr_get_generic_num(e);
-        for (Expr* arg = e->next; arg != NULL; arg = arg->next)
-            total *= expr_get_generic_num(arg);
+        GenericNum total = expr_get_generic_num(first_arg);
+        for (e = CDR(e); !expr_is_nil(e); e = CDR(e))
+            total *= expr_get_generic_num(CAR(e));
 
         ret = expr_new(EXPR_NUM_GENERIC);
         expr_set_generic_num(ret, total);
-    } else if (e->type == EXPR_NUM_INT) {
-        LispInt total = e->val.n;
-        for (Expr* arg = e->next; arg != NULL; arg = arg->next)
-            total *= arg->val.n;
+    } else if (first_arg->type == EXPR_NUM_INT) {
+        LispInt total = first_arg->val.n;
+        for (e = CDR(e); !expr_is_nil(e); e = CDR(e))
+            total *= CAR(e)->val.n;
 
         ret        = expr_new(EXPR_NUM_INT);
         ret->val.n = total;
-    } else if (e->type == EXPR_NUM_FLT) {
-        LispFlt total = e->val.f;
-        for (Expr* arg = e->next; arg != NULL; arg = arg->next)
-            total *= arg->val.f;
+    } else if (first_arg->type == EXPR_NUM_FLT) {
+        LispFlt total = first_arg->val.f;
+        for (e = CDR(e); !expr_is_nil(e); e = CDR(e))
+            total *= CAR(e)->val.f;
 
         ret        = expr_new(EXPR_NUM_FLT);
         ret->val.f = total;
     } else {
-        SL_FATAL("Unhandled numeric type (%s).", exprtype2str(e->type));
+        SL_FATAL("Unhandled numeric type (%s).", exprtype2str(first_arg->type));
     }
 
     return ret;
@@ -174,7 +186,7 @@ Expr* prim_mul(Env* env, Expr* e) {
 
 Expr* prim_div(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_EXPECT(e != NULL, "Expected at least one argument.");
+    SL_EXPECT(!expr_is_nil(e), "Expected at least one argument.");
     SL_EXPECT(expr_list_has_only_numbers(e),
               "Unexpected non-numeric argument.");
 
@@ -182,9 +194,9 @@ Expr* prim_div(Env* env, Expr* e) {
      * The `div' primitive always returns a 'GenericNum' result. For integer
      * division, use `quotient'.
      */
-    GenericNum total = expr_get_generic_num(e);
-    for (Expr* arg = e->next; arg != NULL; arg = arg->next) {
-        const GenericNum n = expr_get_generic_num(arg);
+    GenericNum total = expr_get_generic_num(CAR(e));
+    for (e = CDR(e); !expr_is_nil(e); e = CDR(e)) {
+        const GenericNum n = expr_get_generic_num(CAR(e));
         SL_EXPECT(n != 0, "Trying to divide by zero.");
         total /= n;
     }
@@ -196,7 +208,7 @@ Expr* prim_div(Env* env, Expr* e) {
 
 Expr* prim_mod(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_EXPECT(e != NULL, "Expected at least one argument.");
+    SL_EXPECT(!expr_is_nil(e), "Expected at least one argument.");
     SL_EXPECT(expr_list_has_only_numbers(e),
               "Unexpected non-numeric argument.");
 
@@ -213,9 +225,9 @@ Expr* prim_mod(Env* env, Expr* e) {
      * Note that, although the behavior of `mod' in SL is the same as in Elisp,
      * the `floor' and `/' functions are not.
      */
-    GenericNum total = expr_get_generic_num(e);
-    for (Expr* arg = e->next; arg != NULL; arg = arg->next) {
-        const GenericNum num = expr_get_generic_num(arg);
+    GenericNum total = expr_get_generic_num(CAR(e));
+    for (e = CDR(e); !expr_is_nil(e); e = CDR(e)) {
+        const GenericNum num = expr_get_generic_num(CAR(e));
         SL_EXPECT(num != 0, "Trying to divide by zero.");
         total = fmod(total, num);
         if (num < 0 ? total > 0 : total < 0)
@@ -229,15 +241,18 @@ Expr* prim_mod(Env* env, Expr* e) {
 
 Expr* prim_quotient(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_EXPECT(e != NULL, "Expected at least one argument.");
+    SL_EXPECT(!expr_is_nil(e), "Expected at least one argument.");
+
+    const Expr* first_arg = CAR(e);
+    SL_EXPECT_TYPE(first_arg, EXPR_NUM_INT);
 
     /*
      * The `quotient' function is just like `/', but it only operates with
      * integers.
      */
-    SL_EXPECT_TYPE(e, EXPR_NUM_INT);
-    LispInt total = e->val.n;
-    for (Expr* arg = e->next; arg != NULL; arg = arg->next) {
+    LispInt total = first_arg->val.n;
+    for (e = CDR(e); !expr_is_nil(e); e = CDR(e)) {
+        const Expr* arg = CAR(e);
         SL_EXPECT_TYPE(arg, EXPR_NUM_INT);
         SL_EXPECT(arg->val.n != 0, "Trying to divide by zero.");
         total /= arg->val.n;
@@ -250,7 +265,10 @@ Expr* prim_quotient(Env* env, Expr* e) {
 
 Expr* prim_remainder(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_EXPECT(e != NULL, "Missing arguments.");
+    SL_EXPECT(!expr_is_nil(e), "Expected at least one argument.");
+
+    const Expr* first_arg = CAR(e);
+    SL_EXPECT_TYPE(first_arg, EXPR_NUM_INT);
 
     /*
      * The `remainder' function is just like `mod', but it only operates with
@@ -259,9 +277,9 @@ Expr* prim_remainder(Env* env, Expr* e) {
      *   (+ (remainder dividend divisor)
      *      (* (quotient dividend divisor) divisor))
      */
-    SL_EXPECT_TYPE(e, EXPR_NUM_INT);
-    LispInt total = e->val.n;
-    for (Expr* arg = e->next; arg != NULL; arg = arg->next) {
+    LispInt total = first_arg->val.n;
+    for (e = CDR(e); !expr_is_nil(e); e = CDR(e)) {
+        const Expr* arg = CAR(e);
         SL_EXPECT_TYPE(arg, EXPR_NUM_INT);
         SL_EXPECT(arg->val.n != 0, "Trying to divide by zero.");
         total %= arg->val.n;
@@ -275,15 +293,17 @@ Expr* prim_remainder(Env* env, Expr* e) {
 Expr* prim_round(Env* env, Expr* e) {
     SL_UNUSED(env);
     SL_EXPECT_ARG_NUM(e, 1);
-    SL_EXPECT(EXPR_NUMBER_P(e), "Expected numeric argument.");
 
-    Expr* ret = expr_new(e->type);
-    switch (e->type) {
+    const Expr* arg = CAR(e);
+    SL_EXPECT(EXPR_NUMBER_P(arg), "Expected numeric argument.");
+
+    Expr* ret = expr_new(arg->type);
+    switch (arg->type) {
         case EXPR_NUM_INT:
-            ret->val.n = e->val.n;
+            ret->val.n = arg->val.n;
             break;
         case EXPR_NUM_FLT:
-            ret->val.f = round(e->val.f);
+            ret->val.f = round(arg->val.f);
             break;
         default:
             SL_FATAL("Unhandled numeric type.");
@@ -294,15 +314,17 @@ Expr* prim_round(Env* env, Expr* e) {
 Expr* prim_floor(Env* env, Expr* e) {
     SL_UNUSED(env);
     SL_EXPECT_ARG_NUM(e, 1);
-    SL_EXPECT(EXPR_NUMBER_P(e), "Expected numeric argument.");
 
-    Expr* ret = expr_new(e->type);
-    switch (e->type) {
+    const Expr* arg = CAR(e);
+    SL_EXPECT(EXPR_NUMBER_P(arg), "Expected numeric argument.");
+
+    Expr* ret = expr_new(arg->type);
+    switch (arg->type) {
         case EXPR_NUM_INT:
-            ret->val.n = e->val.n;
+            ret->val.n = arg->val.n;
             break;
         case EXPR_NUM_FLT:
-            ret->val.f = floor(e->val.f);
+            ret->val.f = floor(arg->val.f);
             break;
         default:
             SL_FATAL("Unhandled numeric type.");
@@ -313,15 +335,17 @@ Expr* prim_floor(Env* env, Expr* e) {
 Expr* prim_ceiling(Env* env, Expr* e) {
     SL_UNUSED(env);
     SL_EXPECT_ARG_NUM(e, 1);
-    SL_EXPECT(EXPR_NUMBER_P(e), "Expected numeric argument.");
 
-    Expr* ret = expr_new(e->type);
-    switch (e->type) {
+    const Expr* arg = CAR(e);
+    SL_EXPECT(EXPR_NUMBER_P(arg), "Expected numeric argument.");
+
+    Expr* ret = expr_new(arg->type);
+    switch (arg->type) {
         case EXPR_NUM_INT:
-            ret->val.n = e->val.n;
+            ret->val.n = arg->val.n;
             break;
         case EXPR_NUM_FLT:
-            ret->val.f = ceil(e->val.f);
+            ret->val.f = ceil(arg->val.f);
             break;
         default:
             SL_FATAL("Unhandled numeric type.");
@@ -332,15 +356,17 @@ Expr* prim_ceiling(Env* env, Expr* e) {
 Expr* prim_truncate(Env* env, Expr* e) {
     SL_UNUSED(env);
     SL_EXPECT_ARG_NUM(e, 1);
-    SL_EXPECT(EXPR_NUMBER_P(e), "Expected numeric argument.");
 
-    Expr* ret = expr_new(e->type);
-    switch (e->type) {
+    const Expr* arg = CAR(e);
+    SL_EXPECT(EXPR_NUMBER_P(arg), "Expected numeric argument.");
+
+    Expr* ret = expr_new(arg->type);
+    switch (arg->type) {
         case EXPR_NUM_INT:
-            ret->val.n = e->val.n;
+            ret->val.n = arg->val.n;
             break;
         case EXPR_NUM_FLT:
-            ret->val.f = trunc(e->val.f);
+            ret->val.f = trunc(arg->val.f);
             break;
         default:
             SL_FATAL("Unhandled numeric type.");

--- a/src/prim_bitwise.c
+++ b/src/prim_bitwise.c
@@ -25,10 +25,11 @@
 
 Expr* prim_bit_and(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_EXPECT(e != NULL, "Missing arguments.");
+    SL_EXPECT(!expr_is_nil(e), "Expected at least one argument.");
 
-    LispInt total = e->val.n;
-    for (Expr* arg = e->next; arg != NULL; arg = arg->next) {
+    LispInt total = CAR(e)->val.n;
+    for (e = CDR(e); !expr_is_nil(e); e = CDR(e)) {
+        const Expr* arg = CAR(e);
         SL_EXPECT_TYPE(arg, EXPR_NUM_INT);
         total &= arg->val.n;
     }
@@ -40,10 +41,11 @@ Expr* prim_bit_and(Env* env, Expr* e) {
 
 Expr* prim_bit_or(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_EXPECT(e != NULL, "Missing arguments.");
+    SL_EXPECT(!expr_is_nil(e), "Expected at least one argument.");
 
-    LispInt total = e->val.n;
-    for (Expr* arg = e->next; arg != NULL; arg = arg->next) {
+    LispInt total = CAR(e)->val.n;
+    for (e = CDR(e); !expr_is_nil(e); e = CDR(e)) {
+        const Expr* arg = CAR(e);
         SL_EXPECT_TYPE(arg, EXPR_NUM_INT);
         total |= arg->val.n;
     }
@@ -55,10 +57,11 @@ Expr* prim_bit_or(Env* env, Expr* e) {
 
 Expr* prim_bit_xor(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_EXPECT(e != NULL, "Missing arguments.");
+    SL_EXPECT(!expr_is_nil(e), "Expected at least one argument.");
 
-    LispInt total = e->val.n;
-    for (Expr* arg = e->next; arg != NULL; arg = arg->next) {
+    LispInt total = CAR(e)->val.n;
+    for (e = CDR(e); !expr_is_nil(e); e = CDR(e)) {
+        const Expr* arg = CAR(e);
         SL_EXPECT_TYPE(arg, EXPR_NUM_INT);
         total ^= arg->val.n;
     }
@@ -71,31 +74,39 @@ Expr* prim_bit_xor(Env* env, Expr* e) {
 Expr* prim_bit_not(Env* env, Expr* e) {
     SL_UNUSED(env);
     SL_EXPECT_ARG_NUM(e, 1);
-    SL_EXPECT_TYPE(e, EXPR_NUM_INT);
+
+    const Expr* arg = CAR(e);
+    SL_EXPECT_TYPE(arg, EXPR_NUM_INT);
 
     Expr* ret  = expr_new(EXPR_NUM_INT);
-    ret->val.n = ~(e->val.n);
+    ret->val.n = ~(arg->val.n);
     return ret;
 }
 
 Expr* prim_shr(Env* env, Expr* e) {
     SL_UNUSED(env);
     SL_EXPECT_ARG_NUM(e, 2);
-    SL_EXPECT_TYPE(e, EXPR_NUM_INT);
-    SL_EXPECT_TYPE(e->next, EXPR_NUM_INT);
+
+    const Expr* num = CAR(e);
+    SL_EXPECT_TYPE(num, EXPR_NUM_INT);
+    const Expr* count = CADR(e);
+    SL_EXPECT_TYPE(count, EXPR_NUM_INT);
 
     Expr* ret  = expr_new(EXPR_NUM_INT);
-    ret->val.n = (e->val.n >> e->next->val.n);
+    ret->val.n = (num->val.n >> count->val.n);
     return ret;
 }
 
 Expr* prim_shl(Env* env, Expr* e) {
     SL_UNUSED(env);
     SL_EXPECT_ARG_NUM(e, 2);
-    SL_EXPECT_TYPE(e, EXPR_NUM_INT);
-    SL_EXPECT_TYPE(e->next, EXPR_NUM_INT);
+
+    const Expr* num = CAR(e);
+    SL_EXPECT_TYPE(num, EXPR_NUM_INT);
+    const Expr* count = CADR(e);
+    SL_EXPECT_TYPE(count, EXPR_NUM_INT);
 
     Expr* ret  = expr_new(EXPR_NUM_INT);
-    ret->val.n = (e->val.n << e->next->val.n);
+    ret->val.n = (num->val.n << count->val.n);
     return ret;
 }

--- a/src/prim_io.c
+++ b/src/prim_io.c
@@ -60,10 +60,11 @@ Expr* prim_write(Env* env, Expr* e) {
     SL_UNUSED(env);
     SL_EXPECT_ARG_NUM(e, 1);
 
-    const bool success = expr_write(stdout, e);
+    const Expr* arg    = CAR(e);
+    const bool success = expr_write(stdout, arg);
     SL_EXPECT(success,
               "Couldn't write expression of type '%s'.",
-              exprtype2str(e->type));
+              exprtype2str(arg->type));
 
     return expr_clone(g_tru);
 }
@@ -86,8 +87,9 @@ Expr* prim_scan_str(Env* env, Expr* e) {
 
     const char* delimiters = "\n";
     if (arg_num == 1) {
-        SL_EXPECT_TYPE(e, EXPR_STRING);
-        delimiters = e->val.s;
+        const Expr* arg = CAR(e);
+        SL_EXPECT_TYPE(arg, EXPR_STRING);
+        delimiters = arg->val.s;
     }
 
     size_t str_pos = 0;
@@ -117,19 +119,23 @@ Expr* prim_scan_str(Env* env, Expr* e) {
 Expr* prim_print_str(Env* env, Expr* e) {
     SL_UNUSED(env);
     SL_EXPECT_ARG_NUM(e, 1);
-    SL_EXPECT_TYPE(e, EXPR_STRING);
 
-    printf("%s", e->val.s);
-    return expr_clone(e);
+    const Expr* arg = CAR(e);
+    SL_EXPECT_TYPE(arg, EXPR_STRING);
+
+    printf("%s", arg->val.s);
+    return expr_clone(arg);
 }
 
 Expr* prim_error(Env* env, Expr* e) {
     SL_UNUSED(env);
     SL_EXPECT_ARG_NUM(e, 1);
-    SL_EXPECT_TYPE(e, EXPR_STRING);
+
+    const Expr* arg = CAR(e);
+    SL_EXPECT_TYPE(arg, EXPR_STRING);
 
     /*
      * TODO: Use 'prim_format' and '&rest'. Move outside of 'prim_io.c'.
      */
-    return err("%s", e->val.s);
+    return err("%s", arg->val.s);
 }

--- a/src/prim_list.c
+++ b/src/prim_list.c
@@ -196,7 +196,7 @@ Expr* prim_append(Env* env, Expr* e) {
 
     if (!expr_list_has_only_lists(e) &&
         !expr_list_has_only_type(e, EXPR_STRING))
-        return err("Expected arguments of the same type.");
+        return err("All arguments must be proper lists or strings.");
 
     const Expr* first_element = CAR(e);
 

--- a/src/prim_list.c
+++ b/src/prim_list.c
@@ -25,34 +25,34 @@
 #include "include/memory.h"
 #include "include/primitives.h"
 
-/* Used by 'prim_append' when receiving list arguments */
+/*
+ * Used by 'prim_append' when receiving list arguments.
+ *
+ * TODO: We could add an 'expr_list_append' function that takes two lists and
+ * overwrites the last CDR of the first list with a pointer to the second
+ * list. This could be used in 'handle_backquote_arg', inside 'prim_special.c'.
+ */
 static Expr* list_append(Expr* e) {
-    SL_ASSERT(e != NULL);
-
     Expr dummy_copy;
-    dummy_copy.next = NULL;
-    Expr* cur_copy  = &dummy_copy;
+    dummy_copy.val.pair.cdr = g_nil;
+    Expr* cur_copy          = &dummy_copy;
 
-    for (Expr* arg = e; arg != NULL; arg = arg->next) {
-        SL_ASSERT(arg->type == EXPR_PARENT);
-
-        if (arg->val.children == NULL)
+    for (; !expr_is_nil(e); e = CDR(e)) {
+        const Expr* arg = CAR(e);
+        SL_ASSERT(expr_is_proper_list(arg));
+        if (expr_is_nil(arg))
             continue;
 
-        cur_copy->next = expr_list_clone(arg->val.children);
-        while (cur_copy->next != NULL)
-            cur_copy = cur_copy->next;
+        CDR(cur_copy) = expr_clone_recur(arg);
+        while (!expr_is_nil(CDR(cur_copy)))
+            cur_copy = CDR(cur_copy);
     }
 
-    Expr* ret         = expr_new(EXPR_PARENT);
-    ret->val.children = dummy_copy.next;
-    return ret;
+    return dummy_copy.val.pair.cdr;
 }
 
 /* Used by 'prim_append' when receiving string arguments */
 static Expr* string_append(Expr* e) {
-    SL_ASSERT(e != NULL);
-
     /*
      * Calculate the sum of the string lengths, allocate the destination buffer
      * and  concatenate each string using 'stpcpy'.
@@ -63,7 +63,8 @@ static Expr* string_append(Expr* e) {
      * internally.
      */
     size_t total_len = 0;
-    for (Expr* arg = e; arg != NULL; arg = arg->next) {
+    for (const Expr* rem = e; !expr_is_nil(rem); rem = CDR(rem)) {
+        const Expr* arg = CAR(rem);
         SL_ASSERT(arg->type == EXPR_STRING);
         SL_ASSERT(arg->val.s != NULL);
 
@@ -74,8 +75,8 @@ static Expr* string_append(Expr* e) {
     ret->val.s = mem_alloc(total_len + 1);
 
     char* last_copied = ret->val.s;
-    for (Expr* arg = e; arg != NULL; arg = arg->next)
-        last_copied = stpcpy(last_copied, arg->val.s);
+    for (const Expr* rem = e; !expr_is_nil(rem); rem = CDR(rem))
+        last_copied = stpcpy(last_copied, CAR(rem)->val.s);
 
     return ret;
 }
@@ -84,7 +85,7 @@ static Expr* string_append(Expr* e) {
 
 /*
  * TODO: This doesn't need to be a primitive, we can just `cons' the arguments
- * with 'nil'.
+ * with 'nil'. We should note all unnecessary primitives in 'primitives.h'.
  */
 Expr* prim_list(Env* env, Expr* e) {
     SL_UNUSED(env);
@@ -93,92 +94,92 @@ Expr* prim_list(Env* env, Expr* e) {
      * (list)          ===> nil
      * (list 'a 'b 'c) ===> (a b c)
      */
-    Expr* ret         = expr_new(EXPR_PARENT);
-    ret->val.children = expr_list_clone(e);
-
-    return ret;
+    return expr_clone_recur(e);
 }
 
 /*
- * TODO: Don't create copies, store the reference directly (after adding cons).
+ * TODO: Don't create copies, store the reference directly.
  */
 Expr* prim_cons(Env* env, Expr* e) {
     SL_UNUSED(env);
     SL_EXPECT_ARG_NUM(e, 2);
-    SL_EXPECT_TYPE(e->next, EXPR_PARENT);
 
     /*
-     * (cons a nil)    ===> (a)
-     * (cons a '(b c)) ===> (a b c)
+     * (cons 'a 'b)     ===> (a . b)
+     * (cons 'a '(b c)) ===> (a b c)
+     * (cons 'a nil)    ===> (a)
      */
-    Expr* ret         = expr_new(EXPR_PARENT);
-    ret->val.children = expr_clone_recur(e);
-
-    if (e->next->val.children != NULL)
-        ret->val.children->next = expr_list_clone(e->next->val.children);
+    Expr* ret = expr_new(EXPR_PAIR);
+    CAR(ret)  = expr_clone_recur(expr_list_nth(e, 1));
+    CDR(ret)  = expr_clone_recur(expr_list_nth(e, 2));
 
     return ret;
 }
 
 /*
- * TODO: Don't create a copy, return the reference directly (after adding cons).
+ * TODO: Don't create a copy, return the reference directly.
  */
 Expr* prim_car(Env* env, Expr* e) {
     SL_UNUSED(env);
     SL_EXPECT_ARG_NUM(e, 1);
-    SL_EXPECT_TYPE(e, EXPR_PARENT);
+
+    const Expr* arg = CAR(e);
+    SL_EXPECT(arg->type == EXPR_PAIR || expr_is_nil(arg),
+              "Expected an expression of type '%s' or `nil', got '%s'.",
+              exprtype2str(EXPR_PAIR),
+              exprtype2str(arg->type));
 
     /*
-     * (car '())          ===> nil
-     * (car '(a b c))     ===> a
+     * (car nil)          ===> nil
+     * (car '(a . b))     ===> a
      * (car '((a b) y z)) ===> (a b)
      */
-    if (expr_is_nil(e))
-        return expr_clone(e);
+    if (expr_is_nil(arg))
+        return expr_clone(arg);
 
-    return expr_clone_recur(e->val.children);
+    return expr_clone_recur(CAR(arg));
 }
 
 /*
- * TODO: Don't create a copy, return the reference directly (after adding cons).
+ * TODO: Don't create a copy, return the reference directly.
  */
 Expr* prim_cdr(Env* env, Expr* e) {
     SL_UNUSED(env);
     SL_EXPECT_ARG_NUM(e, 1);
-    SL_EXPECT_TYPE(e, EXPR_PARENT);
+
+    const Expr* arg = CAR(e);
+    SL_EXPECT(arg->type == EXPR_PAIR || expr_is_nil(arg),
+              "Expected an expression of type '%s' or `nil', got '%s'.",
+              exprtype2str(EXPR_PAIR),
+              exprtype2str(arg->type));
 
     /*
-     * (cdr '())          ===> nil
-     * (cdr '(a))         ===> nil
+     * (cdr nil)          ===> nil
+     * (cdr '(a . b))     ===> b
      * (cdr '(a b c))     ===> (b c)
      * (cdr '((a b) y z)) ===> (y z)
      */
-    Expr* ret = expr_new(EXPR_PARENT);
+    if (expr_is_nil(arg))
+        return expr_clone(arg);
 
-    if (e->val.children == NULL || e->val.children->next == NULL)
-        ret->val.children = NULL;
-    else
-        ret->val.children = expr_list_clone(e->val.children->next);
-
-    return ret;
+    return expr_clone_recur(CDR(arg));
 }
 
 Expr* prim_length(Env* env, Expr* e) {
     SL_UNUSED(env);
     SL_EXPECT_ARG_NUM(e, 1);
+    const Expr* arg = CAR(e);
 
     LispInt result;
-    switch (e->type) {
-        case EXPR_PARENT:
-            result = expr_list_len(e->val.children);
-            break;
-
-        case EXPR_STRING:
-            result = strlen(e->val.s);
-            break;
-
-        default:
-            return err("Invalid argument of type '%s'.", exprtype2str(e->type));
+    if (expr_is_nil(arg)) {
+        result = 0;
+    } else if (EXPR_PAIR_P(arg)) {
+        SL_EXPECT_PROPER_LIST(arg);
+        result = expr_list_len(arg);
+    } else if (EXPR_STR_P(arg)) {
+        result = strlen(arg->val.s);
+    } else {
+        return err("Invalid argument of type '%s'.", exprtype2str(arg->type));
     }
 
     Expr* ret  = expr_new(EXPR_NUM_INT);
@@ -189,38 +190,30 @@ Expr* prim_length(Env* env, Expr* e) {
 Expr* prim_append(Env* env, Expr* e) {
     SL_UNUSED(env);
 
-    if (e == NULL) {
-        /* (append) ===> nil */
-        Expr* ret         = expr_new(EXPR_PARENT);
-        ret->val.children = NULL;
-        return ret;
-    }
+    /* (append) ===> nil */
+    if (expr_is_nil(e))
+        return expr_clone(g_nil);
 
-    if (!expr_list_is_homogeneous(e))
+    if (!expr_list_has_only_lists(e) &&
+        !expr_list_has_only_type(e, EXPR_STRING))
         return err("Expected arguments of the same type.");
 
-    Expr* ret;
-    switch (e->type) {
-        case EXPR_PARENT:
-            /*
-             * (append nil)               ===> nil
-             * (append '(a b) ... '(y z)) ===> (a b ... y z)
-             */
-            ret = list_append(e);
-            break;
+    const Expr* first_element = CAR(e);
 
-        case EXPR_STRING:
-            /*
-             * (append "")              ===> ""
-             * (append "abc" ... "xyz") ===> "abc...xyz"
-             */
-            ret = string_append(e);
-            break;
+    /*
+     * (append nil)               ===> nil
+     * (append '(a b) ... '(y z)) ===> (a b ... y z)
+     */
+    if (expr_is_proper_list(first_element))
+        return list_append(e);
 
-        default:
-            ret = err("Invalid argument of type '%s'.", exprtype2str(e->type));
-            break;
-    }
+    /*
+     * (append "")              ===> ""
+     * (append "abc" ... "xyz") ===> "abc...xyz"
+     */
+    if (EXPR_STR_P(first_element))
+        return string_append(e);
 
-    return ret;
+    return err("Invalid argument of type '%s'.",
+               exprtype2str(first_element->type));
 }

--- a/src/prim_logic.c
+++ b/src/prim_logic.c
@@ -30,8 +30,8 @@ Expr* prim_equal(Env* env, Expr* e) {
     bool result = true;
 
     /* (A == B == ...) */
-    for (Expr* arg = e; arg->next != NULL; arg = arg->next) {
-        if (!expr_equal(arg, arg->next)) {
+    for (; !expr_is_nil(CDR(e)); e = CDR(e)) {
+        if (!expr_equal(CAR(e), CADR(e))) {
             result = false;
             break;
         }
@@ -49,8 +49,8 @@ Expr* prim_equal_num(Env* env, Expr* e) {
     bool result = true;
 
     /* (N1 == N2 == ...) */
-    for (Expr* arg = e; arg->next != NULL; arg = arg->next) {
-        if (expr_get_generic_num(arg) != expr_get_generic_num(arg->next)) {
+    for (; !expr_is_nil(CDR(e)); e = CDR(e)) {
+        if (expr_get_generic_num(CAR(e)) != expr_get_generic_num(CADR(e))) {
             result = false;
             break;
         }
@@ -66,8 +66,8 @@ Expr* prim_lt(Env* env, Expr* e) {
     bool result = true;
 
     /* (A < B < ...) */
-    for (Expr* arg = e; arg->next != NULL; arg = arg->next) {
-        if (!expr_lt(arg, arg->next)) {
+    for (; !expr_is_nil(CDR(e)); e = CDR(e)) {
+        if (!expr_lt(CAR(e), CADR(e))) {
             result = false;
             break;
         }
@@ -83,8 +83,8 @@ Expr* prim_gt(Env* env, Expr* e) {
     bool result = true;
 
     /* (A > B > ...) */
-    for (Expr* arg = e; arg->next != NULL; arg = arg->next) {
-        if (!expr_gt(arg, arg->next)) {
+    for (; !expr_is_nil(CDR(e)); e = CDR(e)) {
+        if (!expr_gt(CAR(e), CADR(e))) {
             result = false;
             break;
         }

--- a/src/prim_string.c
+++ b/src/prim_string.c
@@ -59,11 +59,11 @@ Expr* prim_write_to_str(Env* env, Expr* e) {
 
 Expr* prim_format(Env* env, Expr* e) {
     SL_UNUSED(env);
-    SL_EXPECT(e != NULL, "Missing arguments.");
-    SL_EXPECT_TYPE(e, EXPR_STRING);
+    SL_EXPECT(!expr_is_nil(e), "Expected at least a format argument.");
 
-    const char* fmt     = e->val.s;
-    const Expr* cur_arg = e->next;
+    SL_EXPECT_TYPE(CAR(e), EXPR_STRING);
+    const char* fmt = CAR(e)->val.s;
+    e               = CDR(e);
 
     size_t dst_pos = 0;
     size_t dst_sz  = FORMAT_BUFSZ;
@@ -87,7 +87,7 @@ Expr* prim_format(Env* env, Expr* e) {
         fmt++;
 
         /* Make sure the user supplied enough arguments. */
-        if (cur_arg == NULL) {
+        if (expr_is_nil(e)) {
             free(dst);
             return err("Not enough arguments for the specified format.");
         }
@@ -143,12 +143,13 @@ Expr* prim_format(Env* env, Expr* e) {
          * Make sure the current format specifier is valid for the current
          * argument.
          */
-        if (expr_type != cur_arg->type) {
+        const Expr* arg = CAR(e);
+        if (expr_type != arg->type) {
             free(dst);
             return err("Format specifier expected argument of type '%s', got "
                        "'%s'.",
                        exprtype2str(expr_type),
-                       exprtype2str(cur_arg->type));
+                       exprtype2str(arg->type));
         }
 
         /*
@@ -157,27 +158,15 @@ Expr* prim_format(Env* env, Expr* e) {
          */
         switch (expr_type) {
             case EXPR_STRING:
-                sl_concat_format(&dst,
-                                 &dst_sz,
-                                 &dst_pos,
-                                 c_format,
-                                 cur_arg->val.s);
+                sl_concat_format(&dst, &dst_sz, &dst_pos, c_format, arg->val.s);
                 break;
 
             case EXPR_NUM_INT:
-                sl_concat_format(&dst,
-                                 &dst_sz,
-                                 &dst_pos,
-                                 c_format,
-                                 cur_arg->val.n);
+                sl_concat_format(&dst, &dst_sz, &dst_pos, c_format, arg->val.n);
                 break;
 
             case EXPR_NUM_FLT:
-                sl_concat_format(&dst,
-                                 &dst_sz,
-                                 &dst_pos,
-                                 c_format,
-                                 cur_arg->val.f);
+                sl_concat_format(&dst, &dst_sz, &dst_pos, c_format, arg->val.f);
                 break;
 
             default:
@@ -186,14 +175,14 @@ Expr* prim_format(Env* env, Expr* e) {
         }
 
         /* Move to the next argument, for the next format specifier. */
-        cur_arg = cur_arg->next;
+        e = CDR(e);
     }
 
 done:
     dst[dst_pos] = '\0';
 
     /*
-     * NOTE: We could warn the user if 'cur_arg != NULL', since that means he
+     * NOTE: We could warn the user if 'e != NULL', since that means he
      * specified to many arguments for this format.
      */
 
@@ -211,25 +200,33 @@ Expr* prim_substring(Env* env, Expr* e) {
     SL_EXPECT(arg_num >= 1 || arg_num <= 3,
               "Expected between 1 and 3 arguments.");
 
-    SL_EXPECT_TYPE(e, EXPR_STRING);
-    const size_t str_len = strlen(e->val.s);
-    LispInt start_idx    = 0;
-    LispInt end_idx      = str_len;
+    /* First argument, string */
+    const Expr* str_expr = expr_list_nth(e, 1);
+    SL_EXPECT_TYPE(str_expr, EXPR_STRING);
+    const size_t str_len = strlen(str_expr->val.s);
 
     /* Second argument, start index */
-    if (arg_num >= 2 && !expr_is_nil(e->next)) {
-        SL_EXPECT_TYPE(e->next, EXPR_NUM_INT);
-        start_idx = e->next->val.n;
-        if (start_idx < 0)
-            start_idx += str_len;
+    LispInt start_idx = 0;
+    if (arg_num >= 2) {
+        const Expr* start_idx_expr = expr_list_nth(e, 2);
+        if (!expr_is_nil(start_idx_expr)) {
+            SL_EXPECT_TYPE(start_idx_expr, EXPR_NUM_INT);
+            start_idx = start_idx_expr->val.n;
+            if (start_idx < 0)
+                start_idx += str_len;
+        }
     }
 
     /* Third argument, end index */
-    if (arg_num >= 3 && !expr_is_nil(e->next->next)) {
-        SL_EXPECT_TYPE(e->next->next, EXPR_NUM_INT);
-        end_idx = e->next->next->val.n;
-        if (end_idx < 0)
-            end_idx += str_len;
+    LispInt end_idx = str_len;
+    if (arg_num >= 3) {
+        const Expr* end_idx_expr = expr_list_nth(e, 3);
+        if (!expr_is_nil(end_idx_expr)) {
+            SL_EXPECT_TYPE(end_idx_expr, EXPR_NUM_INT);
+            end_idx = end_idx_expr->val.n;
+            if (end_idx < 0)
+                end_idx += str_len;
+        }
     }
 
     /*
@@ -248,7 +245,7 @@ Expr* prim_substring(Env* env, Expr* e) {
 
     LispInt dst_i, src_i;
     for (dst_i = 0, src_i = start_idx; src_i < end_idx; dst_i++, src_i++)
-        ret->val.s[dst_i] = e->val.s[src_i];
+        ret->val.s[dst_i] = str_expr->val.s[src_i];
     ret->val.s[dst_i] = '\0';
 
     return ret;
@@ -260,67 +257,66 @@ Expr* prim_re_match_groups(Env* env, Expr* e) {
     SL_UNUSED(env);
 
     const size_t arg_num = expr_list_len(e);
-    SL_EXPECT(arg_num >= 2 || arg_num <= 3, "Expected 2 or 3 arguments.");
-
-    SL_EXPECT_TYPE(e, EXPR_STRING);
-    const char* pattern = e->val.s;
-
-    SL_EXPECT_TYPE(e->next, EXPR_STRING);
-    const char* string = e->next->val.s;
-
-    const bool ignore_case = (arg_num >= 3 && !expr_is_nil(e->next->next));
+    SL_EXPECT(arg_num == 2 || arg_num == 3, "Expected 2 or 3 arguments.");
 
     /*
      * Argument syntax: (regexp string &optional ignore-case)
      *
-     * The `re-match-groups' function returns a list of matches. The first match
-     * corresponds to the entire regular expression, and the rest correspond to
-     * each parenthesized sub-expression.  Only the matches are included in the
-     * returned list, so `nil' means that no match was found for the entire
-     * expression.
+     * The `re-match-groups' function returns a list of matches. Each item in
+     * the returned list is a pair with two integers corresponding to the start
+     * and end indexes of that match inside 'string'. Therefore, the structure
+     * of the returned list is:
      *
-     * Each item in the returned list is a list of two integers corresponding to
-     * the start and end indexes of that match inside 'string'.
+     *   ((START . END)
+     *    (START . END)
+     *    ...
+     *    (START . END))
+     *
+     * The first match corresponds to the entire regular expression, and the
+     * rest correspond to each parenthesized sub-expression. Only the matches
+     * are included in the returned list, so `nil' means that no match was found
+     * for the entire expression.
      *
      * It uses Extended Regular Expression (ERE) syntax. See:
      *   https://www.gnu.org/software/sed/manual/html_node/ERE-syntax.html
      *   https://www.gnu.org/software/sed/manual/html_node/BRE-vs-ERE.html
      *   https://www.gnu.org/software/sed/manual/html_node/Character-Classes-and-Bracket-Expressions.html
      */
-    Expr* ret = expr_new(EXPR_PARENT);
+    SL_EXPECT_TYPE(CAR(e), EXPR_STRING);
+    const char* pattern = CAR(e)->val.s;
+
+    SL_EXPECT_TYPE(CADR(e), EXPR_STRING);
+    const char* string = CADR(e)->val.s;
+
+    const bool ignore_case =
+      (arg_num >= 3 && !expr_is_nil(expr_list_nth(e, 3)));
 
     size_t nmatch;
     regmatch_t* pmatch;
-    if (!sl_regex_match_groups(pattern,
-                               string,
-                               ignore_case,
-                               &nmatch,
-                               &pmatch)) {
-        ret->val.children = NULL;
-        return ret;
-    }
+    if (!sl_regex_match_groups(pattern, string, ignore_case, &nmatch, &pmatch))
+        return expr_clone(g_nil);
 
     Expr dummy_copy;
-    dummy_copy.next = NULL;
-    Expr* cur_copy  = &dummy_copy;
+    dummy_copy.val.pair.cdr = g_nil;
+    Expr* cur_copy          = &dummy_copy;
 
     for (size_t i = 0; i < nmatch; i++) {
         if (pmatch[i].rm_so == -1 || pmatch[i].rm_eo == -1)
             break;
 
         /* (cons start-offset end-offset) */
-        Expr* match_pair                      = expr_new(EXPR_PARENT);
-        match_pair->val.children              = expr_new(EXPR_NUM_INT);
-        match_pair->val.children->val.n       = pmatch[i].rm_so;
-        match_pair->val.children->next        = expr_new(EXPR_NUM_INT);
-        match_pair->val.children->next->val.n = pmatch[i].rm_eo;
+        Expr* match_pair       = expr_new(EXPR_PAIR);
+        CAR(match_pair)        = expr_new(EXPR_NUM_INT);
+        CAR(match_pair)->val.n = pmatch[i].rm_so;
+        CDR(match_pair)        = expr_new(EXPR_NUM_INT);
+        CDR(match_pair)->val.n = pmatch[i].rm_eo;
 
-        cur_copy->next = match_pair;
-        cur_copy       = cur_copy->next;
+        CDR(cur_copy) = expr_new(EXPR_PAIR);
+        cur_copy      = CDR(cur_copy);
+        CAR(cur_copy) = match_pair;
+        CDR(cur_copy) = g_nil;
     }
 
-    ret->val.children = dummy_copy.next;
-
     free(pmatch);
-    return ret;
+    return dummy_copy.val.pair.cdr;
 }

--- a/src/prim_type.c
+++ b/src/prim_type.c
@@ -61,9 +61,13 @@ Expr* prim_is_string(Env* env, Expr* e) {
     return (result) ? expr_clone(g_tru) : expr_clone(g_nil);
 }
 
-Expr* prim_is_list(Env* env, Expr* e) {
+/*
+ * TODO: `list?' function. Probably better to make it a primitive, although it's
+ * not necessary.
+ */
+Expr* prim_is_pair(Env* env, Expr* e) {
     SL_UNUSED(env);
-    const bool result = expr_list_has_only_type(e, EXPR_PARENT);
+    const bool result = expr_list_has_only_type(e, EXPR_PAIR);
     return (result) ? expr_clone(g_tru) : expr_clone(g_nil);
 }
 
@@ -91,20 +95,24 @@ Expr* prim_is_macro(Env* env, Expr* e) {
 Expr* prim_int2flt(Env* env, Expr* e) {
     SL_UNUSED(env);
     SL_EXPECT_ARG_NUM(e, 1);
-    SL_EXPECT_TYPE(e, EXPR_NUM_INT);
+
+    const Expr* arg = CAR(e);
+    SL_EXPECT_TYPE(arg, EXPR_NUM_INT);
 
     Expr* ret  = expr_new(EXPR_NUM_FLT);
-    ret->val.f = (LispFlt)e->val.n;
+    ret->val.f = (LispFlt)arg->val.n;
     return ret;
 }
 
 Expr* prim_flt2int(Env* env, Expr* e) {
     SL_UNUSED(env);
     SL_EXPECT_ARG_NUM(e, 1);
-    SL_EXPECT_TYPE(e, EXPR_NUM_FLT);
+
+    const Expr* arg = CAR(e);
+    SL_EXPECT_TYPE(arg, EXPR_NUM_FLT);
 
     Expr* ret  = expr_new(EXPR_NUM_INT);
-    ret->val.n = (LispInt)e->val.f;
+    ret->val.n = (LispInt)arg->val.f;
     return ret;
 }
 
@@ -115,10 +123,12 @@ Expr* prim_flt2int(Env* env, Expr* e) {
 Expr* prim_int2str(Env* env, Expr* e) {
     SL_UNUSED(env);
     SL_EXPECT_ARG_NUM(e, 1);
-    SL_EXPECT_TYPE(e, EXPR_NUM_INT);
+
+    const Expr* arg = CAR(e);
+    SL_EXPECT_TYPE(arg, EXPR_NUM_INT);
 
     char* s;
-    const size_t written = int2str(e->val.n, &s);
+    const size_t written = int2str(arg->val.n, &s);
     SL_EXPECT(written > 0, "Failed to convert Integer to String.");
 
     Expr* ret  = expr_new(EXPR_STRING);
@@ -129,10 +139,12 @@ Expr* prim_int2str(Env* env, Expr* e) {
 Expr* prim_flt2str(Env* env, Expr* e) {
     SL_UNUSED(env);
     SL_EXPECT_ARG_NUM(e, 1);
-    SL_EXPECT_TYPE(e, EXPR_NUM_FLT);
+
+    const Expr* arg = CAR(e);
+    SL_EXPECT_TYPE(arg, EXPR_NUM_FLT);
 
     char* s;
-    const size_t written = flt2str(e->val.f, &s);
+    const size_t written = flt2str(arg->val.f, &s);
     SL_EXPECT(written > 0, "Failed to convert Float to String.");
 
     Expr* ret  = expr_new(EXPR_STRING);
@@ -143,19 +155,23 @@ Expr* prim_flt2str(Env* env, Expr* e) {
 Expr* prim_str2int(Env* env, Expr* e) {
     SL_UNUSED(env);
     SL_EXPECT_ARG_NUM(e, 1);
-    SL_EXPECT_TYPE(e, EXPR_STRING);
+
+    const Expr* arg = CAR(e);
+    SL_EXPECT_TYPE(arg, EXPR_STRING);
 
     Expr* ret  = expr_new(EXPR_NUM_INT);
-    ret->val.n = strtoll(e->val.s, NULL, STRTOLL_ANY_BASE);
+    ret->val.n = strtoll(arg->val.s, NULL, STRTOLL_ANY_BASE);
     return ret;
 }
 
 Expr* prim_str2flt(Env* env, Expr* e) {
     SL_UNUSED(env);
     SL_EXPECT_ARG_NUM(e, 1);
-    SL_EXPECT_TYPE(e, EXPR_STRING);
+
+    const Expr* arg = CAR(e);
+    SL_EXPECT_TYPE(arg, EXPR_STRING);
 
     Expr* ret  = expr_new(EXPR_NUM_FLT);
-    ret->val.f = strtod(e->val.s, NULL);
+    ret->val.f = strtod(arg->val.s, NULL);
     return ret;
 }

--- a/test/lists.lisp
+++ b/test/lists.lisp
@@ -13,16 +13,20 @@
 (append '(a) '(b c) '(d))  ; Expected: (a b c d)
 (append '(a b) nil '(c d)) ; Expected: (a b c d)
 
-(cons 'a nil)        ; Expected: (a)
-(cons 'a '(b c))     ; Expected: (a b c)
-(cons '(a b) '(y z)) ; Expected: ((a b) y z)
+(cons 'a nil)              ; Expected: (a)
+(cons 'a 'b)               ; Expected: (a . b)
+(cons 'a '(b . (c . nil))) ; Expected: (a b c)
+(cons 'a '(b c))           ; Expected: (a b c)
+(cons '(a b) '(y z))       ; Expected: ((a b) y z)
 
-(car nil)    ; Expected: nil
-(car '(a))   ; Expected: a
-(car '(a b)) ; Expected: a
+(car nil)      ; Expected: nil
+(car '(a))     ; Expected: a
+(car '(a . b)) ; Expected: a
+(car '(a b))   ; Expected: a
 
 (cdr nil)      ; Expected: nil
 (cdr '(a))     ; Expected: nil
+(cdr '(a . b)) ; Expected: b
 (cdr '(a b c)) ; Expected: (b c)
 
 (length  nil)     ; Expected: 0


### PR DESCRIPTION
Replace linked lists approach for expression lists with proper cons-pairs. Most of the files had to be changed. See my [blog article](https://8dcc.github.io/programming/cons-of-cons.html) for more information.

General changes:

* The `expr_is_nil` function now only admits symbols with a value of "nil",
  since there are no expressions of type "List".
* Make `expr_list_print` static, add `print_func` argument.
* Add more tests for cons pairs.

New functions and callable macros:

* Add `expr_is_proper_list` function.
* Add `expr_list_nth` function.
* Add `expr_list_has_only_lists` function, used in `prim_append`.
* Add `SL_EXPECT_PROPER_LIST` callable macro.
* Add `CAR`, `CDR`, `CADR` and `CDDR` callable macros.

Renamed functions and macros:

* Replace old `EXPR_PARENT` macro with `EXPR_PAIR`.
* Replace `EXPR_LST_P` callable macro with `EXPR_PAIR_P`.
* Rename `expr_list_is_member` function to `expr_is_member`.
* Replace `prim_is_list` C function (that used to check for `EXPR_PARENT`) and
  `list?` Lisp function with `prim_is_pair` and `pair?`, respectively.

Removed functions:

* Remove `expr_list_clone` function, since we can now clone the a whole tree if
  needed with `expr_clone_recur`.
* Remove `expr_list_equal` function.
* Remove `expr_list_write` function.
* Remove `mark_lambdactx` static function from `garbage_collector.c`.

TODO comments:

* About adding a `mapcar` C function, in `eval_list`.
* About adding a `SL_EXPECT_LEN` callable macro, in `SL_EXPECT_ARG_NUM`.
* About renaming the argument names in C primitives, in `SL_EXPECT_ARG_NUM`.
* About adding `TOKEN_DOT` to lexer, in `parse_recur`.
* About allowing dot inside lists to indicate the CDR, in `parse_recur`.
* About `list?` Lisp function.
